### PR TITLE
Add braces plugin

### DIFF
--- a/lib/plugins/braces.js
+++ b/lib/plugins/braces.js
@@ -25,15 +25,15 @@ module.exports = function braces(parser, type) {
       
       removeCount = 0;
       removeCount += wtree.splice(braceDetail.open.left+1, braceDetail.open.lengthLeft).length;
-      removeCount += wtree.splice(braceDetail.open.center+1-removeCount, braceDetail.open.lengthRight).length;
+      //removeCount += wtree.splice(braceDetail.open.center+1-removeCount, braceDetail.open.lengthRight).length;
       removeCount += wtree.splice(braceDetail.close.left+1-removeCount, braceDetail.close.lengthLeft).length;
       //removeCount += wtree.splice(braceDetail.close.center+1-removeCount, braceDetail.close.lengthRight).length;
       globalRemoveCount += removeCount;
       
-      namedType = new RegExp('^[\t ]*{\n$').test(type) ? 'sameLine' : type.indexOf('\n') === 0 ? 'newLine' : null;
+      namedType = new RegExp('^[\t ]*{\\n$').test(type) ? 'sameLine' : type.indexOf('\n') === 0 ? 'newLine' : null;
       // opening braces
       if(namedType === 'sameLine') {
-        token.value = type + braceDetail.indent;
+        token.value = type;
       }
       if(namedType === 'newLine') {
         token.value = '\n' + braceDetail.indent + '{\n';

--- a/lib/plugins/braces.js
+++ b/lib/plugins/braces.js
@@ -102,6 +102,10 @@ function getLineIndentation(wtree, index) {
         indent = match[1];
       }
     }
+    // case for expressions that are on different lines
+    else if(wtree[index].name === 11 /* PUNCTUACTION */ && wtree[index].value === ')') {
+      index = wtree[index].twin.tokposw + 1;
+    }
     else {
       indent = '';
     }

--- a/lib/plugins/braces.js
+++ b/lib/plugins/braces.js
@@ -12,6 +12,7 @@ module.exports = function braces(parser, type) {
     sun: ['\n{\n', '\n}'],
     gnu: ['\n  {\n', '\n  }']
   };
+  var removeCount = 0;
   var wtree = parser.tokenizer.wtree;
   
   btree.forEach(function(token) {
@@ -19,13 +20,18 @@ module.exports = function braces(parser, type) {
         // don't do anything for these constructions: {}
         token.tokposw+1 !== token.twin.tokposw) {
       braceDetail = {
-        open: getStripPositions(wtree, token),
-        close: getStripPositions(wtree, token.twin)
+        open: getStripPositions(wtree, token, removeCount),
+        close: getStripPositions(wtree, token.twin, removeCount)
       }
       braceDetail.open.center = token.tokposw;
       braceDetail.close.center = token.twin.tokposw;
-      braceDetail.indent = getLineIndentation(wtree, braceDetail.open.left);
+      braceDetail.indent = getLineIndentation(wtree, braceDetail.open.left, removeCount);
       braceDetails.push(braceDetail);
+      
+      removeCount += wtree.splice(braceDetail.open.left+1-removeCount, braceDetail.open.center-braceDetail.open.left-1).length;
+      removeCount += wtree.splice(braceDetail.open.center+1-removeCount, braceDetail.open.right-braceDetail.open.center-1).length;
+      removeCount += wtree.splice(braceDetail.close.left+1-removeCount, braceDetail.close.center-braceDetail.close.left-1).length;
+      removeCount += wtree.splice(braceDetail.close.center+1-removeCount, braceDetail.close.right-braceDetail.close.center-1).length;
       
       // manipulate braces
       if(type === 'knr') {
@@ -40,29 +46,23 @@ module.exports = function braces(parser, type) {
       token.twin.value = '\n' + braceDetail.indent + '}\n';
     }
   });
-  var removeCount = 0;
   braceDetails.forEach(function(detail) {
-    removeCount += wtree.splice(detail.open.left+1-removeCount, detail.open.center-detail.open.left-1).length;
-    removeCount += wtree.splice(detail.open.center+1-removeCount, detail.open.right-detail.open.center-1).length;
-    removeCount += wtree.splice(detail.close.left+1-removeCount, detail.close.center-detail.close.left-1).length;
-    removeCount += wtree.splice(detail.close.center+1-removeCount, detail.close.right-detail.close.center-1).length;
+    
   });
   //console.log(getTreeString(wtree));
 };
 
-function getStripPositions(wtree, braceToken) {
+function getStripPositions(wtree, braceToken, removeCount) {
   var leftTokenPos;
   var rightTokenPos;
-  var index = braceToken.tokposw;
-  var leftTokenPos = braceToken.tokposw;
-  var rightTokenPos = braceToken.tokposw;
+  var index = leftTokenPos = rightTokenPos = braceToken.tokposw - removeCount;
   
-  while(wtree[leftTokenPos] && 
-      (wtree[leftTokenPos].name === 9 /*WHITE_SPACE*/ || wtree[leftTokenPos--].name === 10 /*LINETERMINATOR*/)) {
+  while(wtree[leftTokenPos--] && wtree[leftTokenPos] &&
+      (wtree[leftTokenPos].name === 9 /*WHITE_SPACE*/ || wtree[leftTokenPos].name === 10 /*LINETERMINATOR*/)) {
   };
 
-  while(wtree[rightTokenPos] && 
-      (wtree[rightTokenPos].name === 9 /*WHITE_SPACE*/ || wtree[rightTokenPos++].name === 10 /*LINETERMINATOR*/)) {
+  while(wtree[rightTokenPos++] && wtree[rightTokenPos] &&
+      (wtree[rightTokenPos].name === 9 /*WHITE_SPACE*/ || wtree[rightTokenPos].name === 10 /*LINETERMINATOR*/)) {
   };
 
   return {
@@ -71,8 +71,9 @@ function getStripPositions(wtree, braceToken) {
   }
 }
 
-function getLineIndentation(wtree, index) {
+function getLineIndentation(wtree, index, removeCount) {
   var indent = '';
+  var index = index - removeCount;
   while(wtree[index] && wtree[index].name !== 10 /*LINETERMINATOR*/) {
     if(wtree[index].name === 9 /*WHITE_SPACE*/) {
       indent = wtree[index].value + indent;

--- a/lib/plugins/braces.js
+++ b/lib/plugins/braces.js
@@ -22,13 +22,13 @@ module.exports = function braces(parser, type) {
       
       // clear tokens
       var i;
-      for(i=braceDetail.open.left+1;i<braceDetail.open.center;i++){
+      for(i=braceDetail.open.left+1;i<braceDetail.open.center;i++) {
         wtree[i].value = '';
       }
-      for(i=braceDetail.open.center+1;i<braceDetail.open.right;i++){
+      for(i=braceDetail.open.center+1;i<braceDetail.open.right;i++) {
         wtree[i].value = '';
       }
-      for(i=braceDetail.close.left+1;i<braceDetail.close.center;i++){
+      for(i=braceDetail.close.left+1;i<braceDetail.close.center;i++) {
         wtree[i].value = '';
       }
       
@@ -48,9 +48,6 @@ module.exports = function braces(parser, type) {
       }
     }
   });
-  parser = Parser.parse(Stringifier.stringify(parser));
-  wtree = parser.tokenizer.wtree;
-  //console.log(JSON.stringify(getTreeString(wtree)));
 };
 
 function getStripPositions(wtree, braceToken) {
@@ -58,13 +55,13 @@ function getStripPositions(wtree, braceToken) {
   var rightTokenPos;
   var index = leftTokenPos = rightTokenPos = braceToken.tokposw;
   while(wtree[leftTokenPos--] && wtree[leftTokenPos] &&
-      (wtree[leftTokenPos].name === 9 /*WHITE_SPACE*/ || wtree[leftTokenPos].name === 10 /*LINETERMINATOR*/)) {};
+      (wtree[leftTokenPos].name === 9 /*WHITE_SPACE*/ || wtree[leftTokenPos].name === 10 /*LINETERMINATOR*/));
   if(! wtree[leftTokenPos]) {
     leftTokenPos++;
   }
   
   while(wtree[rightTokenPos++] && wtree[rightTokenPos] &&
-      wtree[rightTokenPos].name === 10 /*LINETERMINATOR*/) {};
+      wtree[rightTokenPos].name === 10 /*LINETERMINATOR*/);
   if(! wtree[rightTokenPos]) {
     rightTokenPos--;
   }
@@ -112,10 +109,4 @@ function getLineIndentation(wtree, index) {
     index -= 1;
   }
   return indent;
-}
-
-function getTreeString(wtree) {
-  return wtree.map(function(token){
-    return token.value;
-  }).join('');
 }

--- a/lib/plugins/braces.js
+++ b/lib/plugins/braces.js
@@ -6,6 +6,7 @@ var removedTokenCount = 0;
 module.exports = function braces(parser, type) {
   var braceDetail;
   var prevToken;
+  var namedType;
   var removeCount;
   var token;
   var btree = parser.tokenizer.btree;
@@ -26,23 +27,27 @@ module.exports = function braces(parser, type) {
       removeCount += wtree.splice(braceDetail.open.left+1, braceDetail.open.lengthLeft).length;
       removeCount += wtree.splice(braceDetail.open.center+1-removeCount, braceDetail.open.lengthRight).length;
       removeCount += wtree.splice(braceDetail.close.left+1-removeCount, braceDetail.close.lengthLeft).length;
-      removeCount += wtree.splice(braceDetail.close.center+1-removeCount, braceDetail.close.lengthRight).length;
+      //removeCount += wtree.splice(braceDetail.close.center+1-removeCount, braceDetail.close.lengthRight).length;
       globalRemoveCount += removeCount;
       
-      // manipulate braces
-      if(type.indexOf("{\n") === 0) {
+      namedType = new RegExp('^[\t ]*{\n$').test(type) ? 'sameLine' : type.indexOf('\n') === 0 ? 'newLine' : null;
+      // opening braces
+      if(namedType === 'sameLine') {
         token.value = type + braceDetail.indent;
       }
-      if(type.indexOf("\n") === 0) {
+      if(namedType === 'newLine') {
         token.value = '\n' + braceDetail.indent + '{\n';
       }
-      token.twin.value = '\n' + braceDetail.indent + '}\n';
+      // closing braces
+      if(typeof(namedType) !== 'undefined') {
+        token.twin.value = '\n' + braceDetail.indent + '}';
+      }
       prevToken = token;
     }
   });
   parser = Parser.parse(Stringifier.stringify(parser));
   wtree = parser.tokenizer.wtree;
-  //console.log(JSON.stringify(getTreeString(wtree)));
+  console.log(JSON.stringify(getTreeString(wtree)));
 };
 
 function getStripPositions(wtree, braceToken, removeCount) {

--- a/lib/plugins/braces.js
+++ b/lib/plugins/braces.js
@@ -50,7 +50,7 @@ module.exports = function braces(parser, type) {
   });
   parser = Parser.parse(Stringifier.stringify(parser));
   wtree = parser.tokenizer.wtree;
-  console.log(JSON.stringify(getTreeString(wtree)));
+  //console.log(JSON.stringify(getTreeString(wtree)));
 };
 
 function getStripPositions(wtree, braceToken) {

--- a/lib/plugins/braces.js
+++ b/lib/plugins/braces.js
@@ -1,6 +1,3 @@
-var Parser = require('../parser');
-var Stringifier = require('../stringifier');
-
 module.exports = function braces(parser, type) {
   var braceDetail;
   var namedType;

--- a/lib/plugins/braces.js
+++ b/lib/plugins/braces.js
@@ -28,10 +28,10 @@ module.exports = function braces(parser, type) {
       braceDetail.indent = getLineIndentation(wtree, braceDetail.open.left, globalRemoveCount);
       
       removeCount = 0;
-      removeCount += wtree.splice(braceDetail.open.left+1, braceDetail.open.center-(braceDetail.open.left+1)).length;
-      removeCount += wtree.splice(braceDetail.open.center+1-removeCount, braceDetail.open.right-(braceDetail.open.center+1)).length;
-      removeCount += wtree.splice(braceDetail.close.left+1-removeCount, braceDetail.close.center-(braceDetail.close.left+1)).length;
-      removeCount += wtree.splice(braceDetail.close.center+1-removeCount, braceDetail.close.right-(braceDetail.close.center+1)).length;
+      removeCount += wtree.splice(braceDetail.open.left+1, braceDetail.open.lengthLeft).length;
+      removeCount += wtree.splice(braceDetail.open.center+1-removeCount, braceDetail.open.lengthRight).length;
+      removeCount += wtree.splice(braceDetail.close.left+1-removeCount, braceDetail.close.lengthLeft).length;
+      removeCount += wtree.splice(braceDetail.close.center+1-removeCount, braceDetail.close.lengthRight).length;
       globalRemoveCount += removeCount;
       
       // manipulate braces
@@ -75,7 +75,9 @@ function getStripPositions(wtree, braceToken, removeCount) {
   return {
     left: leftTokenPos,
     right: rightTokenPos,
-    center: index
+    center: index,
+    lengthLeft: index-(leftTokenPos+1),
+    lengthRight: rightTokenPos-(index+1)
   }
 }
 

--- a/lib/plugins/braces.js
+++ b/lib/plugins/braces.js
@@ -4,6 +4,7 @@ var removedTokenCount = 0;
 
 module.exports = function braces(parser, type) {
   var braceDetail;
+  var removeCount;
   var token;
   var btree = parser.tokenizer.btree;
   var braceDetails = [];
@@ -12,7 +13,7 @@ module.exports = function braces(parser, type) {
     sun: ['\n{\n', '\n}'],
     gnu: ['\n  {\n', '\n  }']
   };
-  var removeCount = 0;
+  var globalRemoveCount = 0;
   var wtree = parser.tokenizer.wtree;
   
   btree.forEach(function(token) {
@@ -20,18 +21,18 @@ module.exports = function braces(parser, type) {
         // don't do anything for these constructions: {}
         token.tokposw+1 !== token.twin.tokposw) {
       braceDetail = {
-        open: getStripPositions(wtree, token, removeCount),
-        close: getStripPositions(wtree, token.twin, removeCount)
+        open: getStripPositions(wtree, token, globalRemoveCount),
+        close: getStripPositions(wtree, token.twin, globalRemoveCount)
       }
-      braceDetail.open.center = token.tokposw;
-      braceDetail.close.center = token.twin.tokposw;
-      braceDetail.indent = getLineIndentation(wtree, braceDetail.open.left, removeCount);
+      braceDetail.indent = getLineIndentation(wtree, braceDetail.open.left, globalRemoveCount);
       braceDetails.push(braceDetail);
       
-      removeCount += wtree.splice(braceDetail.open.left+1-removeCount, braceDetail.open.center-braceDetail.open.left-1).length;
-      removeCount += wtree.splice(braceDetail.open.center+1-removeCount, braceDetail.open.right-braceDetail.open.center-1).length;
-      removeCount += wtree.splice(braceDetail.close.left+1-removeCount, braceDetail.close.center-braceDetail.close.left-1).length;
-      removeCount += wtree.splice(braceDetail.close.center+1-removeCount, braceDetail.close.right-braceDetail.close.center-1).length;
+      removeCount = 0;
+      removeCount += wtree.splice(braceDetail.open.left+1, braceDetail.open.center-(braceDetail.open.left+1)).length;
+      removeCount += wtree.splice(braceDetail.open.center+1-removeCount, braceDetail.open.right-(braceDetail.open.center+1)).length;
+      removeCount += wtree.splice(braceDetail.close.left+1-removeCount, braceDetail.close.center-(braceDetail.close.left+1)).length;
+      removeCount += wtree.splice(braceDetail.close.center+1-removeCount, braceDetail.close.right-(braceDetail.close.center+1)).length;
+      globalRemoveCount += removeCount;
       
       // manipulate braces
       if(type === 'knr') {
@@ -60,14 +61,21 @@ function getStripPositions(wtree, braceToken, removeCount) {
   while(wtree[leftTokenPos--] && wtree[leftTokenPos] &&
       (wtree[leftTokenPos].name === 9 /*WHITE_SPACE*/ || wtree[leftTokenPos].name === 10 /*LINETERMINATOR*/)) {
   };
-
+  if(! wtree[leftTokenPos]) {
+    leftTokenPos++;
+  }
+  
   while(wtree[rightTokenPos++] && wtree[rightTokenPos] &&
       (wtree[rightTokenPos].name === 9 /*WHITE_SPACE*/ || wtree[rightTokenPos].name === 10 /*LINETERMINATOR*/)) {
   };
+  if(! wtree[rightTokenPos]) {
+    rightTokenPos--;
+  }
 
   return {
     left: leftTokenPos,
-    right: rightTokenPos
+    right: rightTokenPos,
+    center: index
   }
 }
 

--- a/lib/plugins/braces.js
+++ b/lib/plugins/braces.js
@@ -1,0 +1,100 @@
+var Parser = require('../parser');
+
+var removedTokenCount = 0;
+
+module.exports = function braces(parser, type) {
+  var braceDetail;
+  var token;
+  var btree = parser.tokenizer.btree;
+  var braceDetails = [];
+  var braceStyles = {
+    knr: ['{\n', '\n}'],
+    sun: ['\n{\n', '\n}'],
+    gnu: ['\n  {\n', '\n  }']
+  };
+  var wtree = parser.tokenizer.wtree;
+  
+  btree.forEach(function(token) {
+    if(token.name === 11 /* PUNCTUACTION */ && token.value == '{' &&
+        // don't do anything for these constructions: {}
+        token.tokposw+1 !== token.twin.tokposw) {
+      braceDetail = {
+        open: getStripPositions(wtree, token),
+        close: getStripPositions(wtree, token.twin)
+      }
+      braceDetail.open.center = token.tokposw;
+      braceDetail.close.center = token.twin.tokposw;
+      braceDetail.indent = getLineIndentation(wtree, braceDetail.open.left);
+      braceDetails.push(braceDetail);
+      
+      // manipulate braces
+      if(type === 'knr') {
+        token.value = '{\n' + braceDetail.indent;
+      }
+      if(type === 'sun') {
+        token.value = '\n' + braceDetail.indent + '{\n';
+      }
+      if(type === 'gnu') {
+        token.value = '\n' + braceDetail.indent + '  {\n';
+      }
+      token.twin.value = '\n' + braceDetail.indent + '}\n';
+    }
+  });
+  var removeCount = 0;
+  braceDetails.forEach(function(detail) {
+    removeCount += wtree.splice(detail.open.left+1-removeCount, detail.open.center-detail.open.left-1).length;
+    removeCount += wtree.splice(detail.open.center+1-removeCount, detail.open.right-detail.open.center-1).length;
+    removeCount += wtree.splice(detail.close.left+1-removeCount, detail.close.center-detail.close.left-1).length;
+    removeCount += wtree.splice(detail.close.center+1-removeCount, detail.close.right-detail.close.center-1).length;
+  });
+  //console.log(getTreeString(wtree));
+};
+
+function getStripPositions(wtree, braceToken) {
+  var leftTokenPos;
+  var rightTokenPos;
+  var index = braceToken.tokposw;
+  var leftTokenPos = braceToken.tokposw;
+  var rightTokenPos = braceToken.tokposw;
+  
+  while(wtree[leftTokenPos] && 
+      (wtree[leftTokenPos].name === 9 /*WHITE_SPACE*/ || wtree[leftTokenPos--].name === 10 /*LINETERMINATOR*/)) {
+  };
+
+  while(wtree[rightTokenPos] && 
+      (wtree[rightTokenPos].name === 9 /*WHITE_SPACE*/ || wtree[rightTokenPos++].name === 10 /*LINETERMINATOR*/)) {
+  };
+
+  return {
+    left: leftTokenPos,
+    right: rightTokenPos
+  }
+}
+
+function getLineIndentation(wtree, index) {
+  var indent = '';
+  while(wtree[index] && wtree[index].name !== 10 /*LINETERMINATOR*/) {
+    if(wtree[index].name === 9 /*WHITE_SPACE*/) {
+      indent = wtree[index].value + indent;
+    }
+    else {
+      indent = '';
+    }
+    index -= 1;
+  }
+  return indent;
+}
+
+function getTokens(wtree, from, to) {
+  var tokens = [];
+  for(;from<to;from++){
+    tokens.push(wtree[from-removedTokenCount]);
+  }
+  return tokens;
+}
+
+function getTreeString(wtree) {
+  return wtree.map(function(token){
+    return token.value;
+  }).join('');
+}

--- a/lib/plugins/braces.js
+++ b/lib/plugins/braces.js
@@ -25,7 +25,7 @@ module.exports = function braces(parser, type) {
       
       removeCount = 0;
       removeCount += wtree.splice(braceDetail.open.left+1, braceDetail.open.lengthLeft).length;
-      //removeCount += wtree.splice(braceDetail.open.center+1-removeCount, braceDetail.open.lengthRight).length;
+      removeCount += wtree.splice(braceDetail.open.center+1-removeCount, braceDetail.open.lengthRight).length;
       removeCount += wtree.splice(braceDetail.close.left+1-removeCount, braceDetail.close.lengthLeft).length;
       //removeCount += wtree.splice(braceDetail.close.center+1-removeCount, braceDetail.close.lengthRight).length;
       globalRemoveCount += removeCount;
@@ -39,9 +39,9 @@ module.exports = function braces(parser, type) {
         token.value = '\n' + braceDetail.indent + '{\n';
       }
       // closing braces
-      if(typeof(namedType) !== 'undefined') {
-        token.twin.value = '\n' + braceDetail.indent + '}';
-      }
+      //if(typeof(namedType) !== 'undefined') {
+      token.twin.value = '\n' + braceDetail.indent + '}';
+      //}
       prevToken = token;
     }
   });
@@ -56,15 +56,13 @@ function getStripPositions(wtree, braceToken, removeCount) {
   var index = leftTokenPos = rightTokenPos = braceToken.tokposw - removeCount;
   
   while(wtree[leftTokenPos--] && wtree[leftTokenPos] &&
-      (wtree[leftTokenPos].name === 9 /*WHITE_SPACE*/ || wtree[leftTokenPos].name === 10 /*LINETERMINATOR*/)) {
-  };
+      (wtree[leftTokenPos].name === 9 /*WHITE_SPACE*/ || wtree[leftTokenPos].name === 10 /*LINETERMINATOR*/)) {};
   if(! wtree[leftTokenPos]) {
     leftTokenPos++;
   }
   
   while(wtree[rightTokenPos++] && wtree[rightTokenPos] &&
-      (wtree[rightTokenPos].name === 9 /*WHITE_SPACE*/ || wtree[rightTokenPos].name === 10 /*LINETERMINATOR*/)) {
-  };
+      wtree[rightTokenPos].name === 10 /*LINETERMINATOR*/)) {};
   if(! wtree[rightTokenPos]) {
     rightTokenPos--;
   }

--- a/lib/plugins/braces.js
+++ b/lib/plugins/braces.js
@@ -9,11 +9,6 @@ module.exports = function braces(parser, type) {
   var removeCount;
   var token;
   var btree = parser.tokenizer.btree;
-  var braceStyles = {
-    knr: ['{\n', '\n}'],
-    sun: ['\n{\n', '\n}'],
-    gnu: ['\n  {\n', '\n  }']
-  };
   var globalRemoveCount = 0;
   var wtree = parser.tokenizer.wtree;
   
@@ -35,14 +30,11 @@ module.exports = function braces(parser, type) {
       globalRemoveCount += removeCount;
       
       // manipulate braces
-      if(type === 'knr') {
-        token.value = '{\n' + braceDetail.indent;
+      if(type.indexOf("{\n") === 0) {
+        token.value = type + braceDetail.indent;
       }
-      if(type === 'sun') {
+      if(type.indexOf("\n") === 0) {
         token.value = '\n' + braceDetail.indent + '{\n';
-      }
-      if(type === 'gnu') {
-        token.value = '\n' + braceDetail.indent + '  {\n';
       }
       token.twin.value = '\n' + braceDetail.indent + '}\n';
       prevToken = token;

--- a/lib/plugins/braces.js
+++ b/lib/plugins/braces.js
@@ -19,7 +19,7 @@ module.exports = function braces(parser, type) {
         close: getStripPositions(wtree, token.twin)
       }
       braceDetail.indent = getLineIndentation(wtree, braceDetail.open.left);
-      //console.log(wtree[token.tokposw]);
+      
       // clear tokens
       var i;
       for(i=braceDetail.open.left+1;i<braceDetail.open.center;i++){
@@ -93,6 +93,14 @@ function getLineIndentation(wtree, index) {
   while(wtree[index] && wtree[index].name !== 10 /*LINETERMINATOR*/) {
     if(wtree[index].name === 9 /*WHITE_SPACE*/) {
       indent = wtree[index].value + indent;
+    }
+    // special case for the braces replacement
+    else if(wtree[index].name === 11 /* PUNCTUACTION */ &&
+      /^[\n\t ]*[{}]$/.test(wtree[index].value)) {
+      var match = wtree[index].value.match(/^[\n]*([\t ]*)[{}]$/);
+      if(match && match.length === 2) {
+        indent = match[1];
+      }
     }
     else {
       indent = '';

--- a/lib/plugins/braces.js
+++ b/lib/plugins/braces.js
@@ -62,7 +62,7 @@ function getStripPositions(wtree, braceToken, removeCount) {
   }
   
   while(wtree[rightTokenPos++] && wtree[rightTokenPos] &&
-      wtree[rightTokenPos].name === 10 /*LINETERMINATOR*/)) {};
+      wtree[rightTokenPos].name === 10 /*LINETERMINATOR*/) {};
   if(! wtree[rightTokenPos]) {
     rightTokenPos--;
   }

--- a/lib/plugins/braces.js
+++ b/lib/plugins/braces.js
@@ -12,13 +12,14 @@ module.exports = function braces(parser, type) {
     if(token.name === 11 /* PUNCTUACTION */ && token.value == '{' &&
         // don't do anything for these constructions: {}
         token.tokposw+1 !== token.twin.tokposw &&
-        !token.isObjectLiteralStart) {
+        !token.isObjectLiteralStart &&
+        !sameLineTokens(wtree, token, token.twin)) {
       braceDetail = {
         open: getStripPositions(wtree, token),
         close: getStripPositions(wtree, token.twin)
       }
       braceDetail.indent = getLineIndentation(wtree, braceDetail.open.left);
-      
+      //console.log(wtree[token.tokposw]);
       // clear tokens
       var i;
       for(i=braceDetail.open.left+1;i<braceDetail.open.center;i++){
@@ -49,7 +50,7 @@ module.exports = function braces(parser, type) {
   });
   parser = Parser.parse(Stringifier.stringify(parser));
   wtree = parser.tokenizer.wtree;
-  //console.log(JSON.stringify(getTreeString(wtree)));
+  console.log(JSON.stringify(getTreeString(wtree)));
 };
 
 function getStripPositions(wtree, braceToken) {
@@ -75,6 +76,15 @@ function getStripPositions(wtree, braceToken) {
     lengthLeft: index-(leftTokenPos+1),
     lengthRight: rightTokenPos-(index+1)
   }
+}
+
+function sameLineTokens(wtree, token, otherToken) {
+  var leftPos  = Math.min(token.tokposw, otherToken.tokposw) +1,
+      rightPos = Math.max(token.tokposw, otherToken.tokposw);
+  if (leftPos === rightPos) return true;
+  return wtree.slice(leftPos, rightPos).filter(function(token) {
+    return token.name === 10 /*LINETERMINATOR*/;
+  }).length === 0;
 }
 
 function getLineIndentation(wtree, index) {

--- a/lib/plugins/braces.js
+++ b/lib/plugins/braces.js
@@ -1,13 +1,14 @@
 var Parser = require('../parser');
+var Stringifier = require('../stringifier');
 
 var removedTokenCount = 0;
 
 module.exports = function braces(parser, type) {
   var braceDetail;
+  var prevToken;
   var removeCount;
   var token;
   var btree = parser.tokenizer.btree;
-  var braceDetails = [];
   var braceStyles = {
     knr: ['{\n', '\n}'],
     sun: ['\n{\n', '\n}'],
@@ -25,7 +26,6 @@ module.exports = function braces(parser, type) {
         close: getStripPositions(wtree, token.twin, globalRemoveCount)
       }
       braceDetail.indent = getLineIndentation(wtree, braceDetail.open.left, globalRemoveCount);
-      braceDetails.push(braceDetail);
       
       removeCount = 0;
       removeCount += wtree.splice(braceDetail.open.left+1, braceDetail.open.center-(braceDetail.open.left+1)).length;
@@ -45,12 +45,12 @@ module.exports = function braces(parser, type) {
         token.value = '\n' + braceDetail.indent + '  {\n';
       }
       token.twin.value = '\n' + braceDetail.indent + '}\n';
+      prevToken = token;
     }
   });
-  braceDetails.forEach(function(detail) {
-    
-  });
-  //console.log(getTreeString(wtree));
+  parser = Parser.parse(Stringifier.stringify(parser));
+  wtree = parser.tokenizer.wtree;
+  //console.log(JSON.stringify(getTreeString(wtree)));
 };
 
 function getStripPositions(wtree, braceToken, removeCount) {

--- a/lib/plugins/braces.js
+++ b/lib/plugins/braces.js
@@ -1,16 +1,11 @@
 var Parser = require('../parser');
 var Stringifier = require('../stringifier');
 
-var removedTokenCount = 0;
-
 module.exports = function braces(parser, type) {
   var braceDetail;
-  var prevToken;
   var namedType;
-  var removeCount;
   var token;
   var btree = parser.tokenizer.btree;
-  var globalRemoveCount = 0;
   var wtree = parser.tokenizer.wtree;
   
   btree.forEach(function(token) {
@@ -18,19 +13,26 @@ module.exports = function braces(parser, type) {
         // don't do anything for these constructions: {}
         token.tokposw+1 !== token.twin.tokposw) {
       braceDetail = {
-        open: getStripPositions(wtree, token, globalRemoveCount),
-        close: getStripPositions(wtree, token.twin, globalRemoveCount)
+        open: getStripPositions(wtree, token),
+        close: getStripPositions(wtree, token.twin)
       }
-      braceDetail.indent = getLineIndentation(wtree, braceDetail.open.left, globalRemoveCount);
+      braceDetail.indent = getLineIndentation(wtree, braceDetail.open.left);
       
-      removeCount = 0;
-      removeCount += wtree.splice(braceDetail.open.left+1, braceDetail.open.lengthLeft).length;
-      removeCount += wtree.splice(braceDetail.open.center+1-removeCount, braceDetail.open.lengthRight).length;
-      removeCount += wtree.splice(braceDetail.close.left+1-removeCount, braceDetail.close.lengthLeft).length;
-      //removeCount += wtree.splice(braceDetail.close.center+1-removeCount, braceDetail.close.lengthRight).length;
-      globalRemoveCount += removeCount;
+      // clear tokens
+      var i;
+      for(i=braceDetail.open.left+1;i<braceDetail.open.center;i++){
+        wtree[i].value = '';
+      }
+      for(i=braceDetail.open.center+1;i<braceDetail.open.right;i++){
+        wtree[i].value = '';
+      }
+      for(i=braceDetail.close.left+1;i<braceDetail.close.center;i++){
+        wtree[i].value = '';
+      }
       
-      namedType = new RegExp('^[\t ]*{\\n$').test(type) ? 'sameLine' : type.indexOf('\n') === 0 ? 'newLine' : null;
+      // ensure that it is escaped right
+      type = type.replace('\\n', '\n');
+      namedType = new RegExp('^[\t ]*{\n$').test(type) ? 'sameLine' : type.indexOf('\n') === 0 ? 'newLine' : null;
       // opening braces
       if(namedType === 'sameLine') {
         token.value = type;
@@ -39,22 +41,20 @@ module.exports = function braces(parser, type) {
         token.value = '\n' + braceDetail.indent + '{\n';
       }
       // closing braces
-      //if(typeof(namedType) !== 'undefined') {
-      token.twin.value = '\n' + braceDetail.indent + '}';
-      //}
-      prevToken = token;
+      if(typeof(namedType) !== 'undefined') {
+        token.twin.value = '\n' + braceDetail.indent + '}';
+      }
     }
   });
   parser = Parser.parse(Stringifier.stringify(parser));
   wtree = parser.tokenizer.wtree;
-  console.log(JSON.stringify(getTreeString(wtree)));
+  //console.log(JSON.stringify(getTreeString(wtree)));
 };
 
-function getStripPositions(wtree, braceToken, removeCount) {
+function getStripPositions(wtree, braceToken) {
   var leftTokenPos;
   var rightTokenPos;
-  var index = leftTokenPos = rightTokenPos = braceToken.tokposw - removeCount;
-  
+  var index = leftTokenPos = rightTokenPos = braceToken.tokposw;
   while(wtree[leftTokenPos--] && wtree[leftTokenPos] &&
       (wtree[leftTokenPos].name === 9 /*WHITE_SPACE*/ || wtree[leftTokenPos].name === 10 /*LINETERMINATOR*/)) {};
   if(! wtree[leftTokenPos]) {
@@ -76,9 +76,9 @@ function getStripPositions(wtree, braceToken, removeCount) {
   }
 }
 
-function getLineIndentation(wtree, index, removeCount) {
+function getLineIndentation(wtree, index) {
   var indent = '';
-  var index = index - removeCount;
+  var index = index;
   while(wtree[index] && wtree[index].name !== 10 /*LINETERMINATOR*/) {
     if(wtree[index].name === 9 /*WHITE_SPACE*/) {
       indent = wtree[index].value + indent;
@@ -89,14 +89,6 @@ function getLineIndentation(wtree, index, removeCount) {
     index -= 1;
   }
   return indent;
-}
-
-function getTokens(wtree, from, to) {
-  var tokens = [];
-  for(;from<to;from++){
-    tokens.push(wtree[from-removedTokenCount]);
-  }
-  return tokens;
 }
 
 function getTreeString(wtree) {

--- a/lib/plugins/braces.js
+++ b/lib/plugins/braces.js
@@ -11,7 +11,8 @@ module.exports = function braces(parser, type) {
   btree.forEach(function(token) {
     if(token.name === 11 /* PUNCTUACTION */ && token.value == '{' &&
         // don't do anything for these constructions: {}
-        token.tokposw+1 !== token.twin.tokposw) {
+        token.tokposw+1 !== token.twin.tokposw &&
+        !token.isObjectLiteralStart) {
       braceDetail = {
         open: getStripPositions(wtree, token),
         close: getStripPositions(wtree, token.twin)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": "*"
   },
   "dependencies": {
-    "zeparser": "0.0.2",
+    "zeparser": "0.0.3",
     "commander": "0.3.3",
     "underscore": "1.2.2"
   },

--- a/syntax.json
+++ b/syntax.json
@@ -3,5 +3,5 @@
   "trimWhitespace": true,
   "quotes": "'",
   "eof": "\n",
-  "braces": "{\n"
+  "braces": " {\n"
 }

--- a/syntax.json
+++ b/syntax.json
@@ -2,5 +2,6 @@
   "addSemicolons": true,
   "trimWhitespace": true,
   "quotes": "'",
-  "eof": "\n"
+  "eof": "\n",
+  "braces": "knr"
 }

--- a/syntax.json
+++ b/syntax.json
@@ -3,5 +3,5 @@
   "trimWhitespace": true,
   "quotes": "'",
   "eof": "\n",
-  "braces": "knr"
+  "braces": "{\n"
 }

--- a/test/integration/test-braces.js
+++ b/test/integration/test-braces.js
@@ -47,6 +47,17 @@ helper.test({
 
 helper.test({
   description:
+    'Simple object',
+  options:
+    {braces: 'knr'},
+  input:
+    'a={foo:bar, bar:baz}',
+  expected:
+    'a={\nfoo:bar, bar:baz\n}\n'
+});
+
+helper.test({
+  description:
     'More complex brace test with spacing',
   options:
     {braces: "knr"},

--- a/test/integration/test-braces.js
+++ b/test/integration/test-braces.js
@@ -32,8 +32,7 @@ helper.test({
   input:
     'a={foo:bar, bar:baz}',
   expected:
-    'a={\nfoo:bar, bar:baz\n' +
-    '}'
+    'a={foo:bar, bar:baz}'
 });
 
 helper.test({

--- a/test/integration/test-braces.js
+++ b/test/integration/test-braces.js
@@ -1,0 +1,58 @@
+var TransformHelper = require('../common').helper('transform_helper');
+var helper = TransformHelper.create();
+
+helper.test({
+  description:
+    'Simple brace test. No wrapping.',
+  options:
+    {braces: 'knr'},
+  input:
+    'function(){}',
+  expected:
+    'function(){}'
+});
+
+helper.test({
+  description:
+    'Simple brace test. Wrapping.',
+  options:
+    {braces: 'knr'},
+  input:
+    'function(){var foo="bar";}',
+  expected:
+    'function(){\nvar foo="bar";\n}\n'
+});
+
+helper.test({
+  description:
+    'Brace test with indentation.',
+  options:
+    {braces: 'knr'},
+  input:
+    '  \tfunction(){var foo="bar";}',
+  expected:
+    '  \tfunction(){\n  \tvar foo="bar";\n  \t}\n'
+});
+
+helper.test({
+  description:
+    'Brace test with spacing.',
+  options:
+    {braces: 'knr'},
+  input:
+    'function()\t\n {\n\t var foo="bar";}',
+  expected:
+    'function(){\nvar foo="bar";\n}\n'
+});
+
+//helper.test({
+//  description:
+//    'Modify braces according c style',
+//  options:
+//    {braces: "knr"},
+//  input:
+//    'var func = function()\n\n  {  /*what*/  switch(foo)  {  case "foo":if(){if(){}}}};',
+//  expected:
+//    'var func = function(){\n/*what*/  switch(foo){\ncase "foo":if(){\nif(){}}}};'
+//});
+

--- a/test/integration/test-braces.js
+++ b/test/integration/test-braces.js
@@ -82,3 +82,22 @@ helper.test({
     '}\n'+
     '};'
 });
+
+helper.test( {
+    description:
+      'Try/catch test',
+    options: {
+  braces: '{\n'
+    },
+  input:
+    'try {\n' +
+    '    var foo = bar;\n' +
+    '} catch (err) {\n' +
+    '}',
+  expected:
+  'try{\n' +
+  '    var foo = bar;\n' +
+  '} catch (err){\n' +
+  '\n' +
+  '}',
+});

--- a/test/integration/test-braces.js
+++ b/test/integration/test-braces.js
@@ -21,7 +21,19 @@ helper.test({
     'function(){var foo="bar";}',
   expected:
     'function(){\nvar foo="bar";\n' +
-    '}\n'
+    '}'
+});
+
+helper.test({
+  description:
+    'Simple object',
+  options:
+    {braces: '{\n'},
+  input:
+    'a={foo:bar, bar:baz}',
+  expected:
+    'a={\nfoo:bar, bar:baz\n' +
+    '}'
 });
 
 helper.test({
@@ -34,7 +46,7 @@ helper.test({
   expected:
     '  \tfunction(){\n' +
     '  \tvar foo="bar";\n' +
-    '  \t}\n'
+    '  \t}'
 });
 
 helper.test({
@@ -49,26 +61,14 @@ helper.test({
   expected:
     'function(){\n'+
     'var foo="bar";\n' +
-    '}\n'
-});
-
-helper.test({
-  description:
-    'Simple object',
-  options:
-    {braces: '{\n'},
-  input:
-    'a={foo:bar, bar:baz}',
-  expected:
-    'a={\nfoo:bar, bar:baz\n' +
-    '}\n'
+    '}'
 });
 
 helper.test({
   description:
     'More complex brace test with spacing',
   options:
-    {braces: "{\n"},
+    {braces: '{\n'},
   input:
     'var func = function()\n' +
     '\n'+
@@ -79,10 +79,6 @@ helper.test({
     'case "foo":if(){\n' +
     'if(){}\n'+
     '}\n'+
-    '\n'+
     '}\n'+
-    '\n'+
-    '}\n'+
-    ';'
+    '};'
 });
-

--- a/test/integration/test-braces.js
+++ b/test/integration/test-braces.js
@@ -5,7 +5,7 @@ helper.test({
   description:
     'Simple brace test. No wrapping.',
   options:
-    {braces: 'knr'},
+    {braces: '{\n'},
   input:
     'function(){}',
   expected:
@@ -16,7 +16,7 @@ helper.test({
   description:
     'Simple brace test. Wrapping.',
   options:
-    {braces: 'knr'},
+    {braces: '{\n'},
   input:
     'function(){var foo="bar";}',
   expected:
@@ -28,7 +28,7 @@ helper.test({
   description:
     'Brace test with indentation.',
   options:
-    {braces: 'knr'},
+    {braces: '{\n'},
   input:
     '  \tfunction(){var foo="bar";}',
   expected:
@@ -41,7 +41,7 @@ helper.test({
   description:
     'Brace test with spacing.',
   options:
-    {braces: 'knr'},
+    {braces: '{\n'},
   input:
     'function()\t\n' +
     ' {\n' +
@@ -56,7 +56,7 @@ helper.test({
   description:
     'Simple object',
   options:
-    {braces: 'knr'},
+    {braces: '{\n'},
   input:
     'a={foo:bar, bar:baz}',
   expected:
@@ -68,7 +68,7 @@ helper.test({
   description:
     'More complex brace test with spacing',
   options:
-    {braces: "knr"},
+    {braces: "{\n"},
   input:
     'var func = function()\n' +
     '\n'+

--- a/test/integration/test-braces.js
+++ b/test/integration/test-braces.js
@@ -18,20 +18,61 @@ helper.test({
   options:
     {braces: '{\n'},
   input:
-    'function(){var foo="bar";}',
+    'function(){\n' +
+    '  var foo="bar";\n' +
+    '}',
   expected:
-    'function(){var foo="bar";}'
+    'function(){\n' +
+    '  var foo="bar";\n' +
+    '}'
 });
 
 helper.test({
   description:
-    'Simple object',
+    'Simple brace test. Same line with space.',
+  options:
+    {braces: ' {\n'},
+  input:
+    '  function(){\n' +
+    '    var foo="bar";\n' +
+    '  }',
+  expected:
+    '  function() {\n' +
+    '    var foo="bar";\n' +
+    '  }'
+});
+
+helper.test({
+  description:
+    'Simple brace test. Next line.',
+  options:
+    {braces: '\n{'},
+  input:
+    '  function(){\n' +
+    '    var foo="bar";\n' +
+    '  }',
+  expected:
+    '  function()\n' +
+    '  {\n' + 
+    '    var foo="bar";\n' +
+    '  }'
+});
+
+helper.test({
+  description:
+    'Simple object (no manipulation)',
   options:
     {braces: '{\n'},
   input:
-    'a={foo:bar, bar:baz}',
+    'a={\n' +
+    '  foo:bar,\n' +
+    '  bar:baz\n' +
+    '};',
   expected:
-    'a={foo:bar, bar:baz}'
+    'a={\n' +
+    '  foo:bar,\n' +
+    '  bar:baz\n' +
+    '};'
 });
 
 helper.test({
@@ -43,6 +84,23 @@ helper.test({
     '  \tfunction(){var foo="bar";}',
   expected:
     '  \tfunction(){var foo="bar";}'
+});
+
+helper.test({
+  description:
+    'Brace test with indentation, statement on two lines.',
+  options:
+    {braces: '{\n'},
+  input:
+    '  if(a == b &&\n' +
+    '      b == c){\n' +
+    '    var foo="bar";\n' +
+    '  }',
+  expected:
+    '  if(a == b &&\n' +
+    '      b == c){\n' +
+    '    var foo="bar";\n' +
+    '  }',
 });
 
 helper.test({

--- a/test/integration/test-braces.js
+++ b/test/integration/test-braces.js
@@ -47,7 +47,7 @@ helper.test({
 
 //helper.test({
 //  description:
-//    'Modify braces according c style',
+//    'More complex brace test with spacing',
 //  options:
 //    {braces: "knr"},
 //  input:

--- a/test/integration/test-braces.js
+++ b/test/integration/test-braces.js
@@ -60,7 +60,7 @@ helper.test({
     '}'
 });
 
-helper.test(true, {
+helper.test({
   description:
     'More complex brace test with spacing',
   options:

--- a/test/integration/test-braces.js
+++ b/test/integration/test-braces.js
@@ -20,7 +20,8 @@ helper.test({
   input:
     'function(){var foo="bar";}',
   expected:
-    'function(){\nvar foo="bar";\n}\n'
+    'function(){\nvar foo="bar";\n' +
+    '}\n'
 });
 
 helper.test({
@@ -31,7 +32,9 @@ helper.test({
   input:
     '  \tfunction(){var foo="bar";}',
   expected:
-    '  \tfunction(){\n  \tvar foo="bar";\n  \t}\n'
+    '  \tfunction(){\n' +
+    '  \tvar foo="bar";\n' +
+    '  \t}\n'
 });
 
 helper.test({
@@ -40,9 +43,13 @@ helper.test({
   options:
     {braces: 'knr'},
   input:
-    'function()\t\n {\n\t var foo="bar";}',
+    'function()\t\n' +
+    ' {\n' +
+    '\t var foo="bar";}',
   expected:
-    'function(){\nvar foo="bar";\n}\n'
+    'function(){\n'+
+    'var foo="bar";\n' +
+    '}\n'
 });
 
 helper.test({
@@ -53,7 +60,8 @@ helper.test({
   input:
     'a={foo:bar, bar:baz}',
   expected:
-    'a={\nfoo:bar, bar:baz\n}\n'
+    'a={\nfoo:bar, bar:baz\n' +
+    '}\n'
 });
 
 helper.test({
@@ -62,8 +70,19 @@ helper.test({
   options:
     {braces: "knr"},
   input:
-    'var func = function()\n\n  {  /*what*/  switch(foo)  {  case "foo":if(){if(){}}}};',
+    'var func = function()\n' +
+    '\n'+
+    '  {  /*what*/  switch(foo)  {  case "foo":if(){if(){}}}};',
   expected:
-    'var func = function(){\n/*what*/  switch(foo){\ncase "foo":if(){\nif(){}\n}\n\n}\n\n}\n;'
+    'var func = function(){\n' +
+    '/*what*/  switch(foo){\n' + 
+    'case "foo":if(){\n' +
+    'if(){}\n'+
+    '}\n'+
+    '\n'+
+    '}\n'+
+    '\n'+
+    '}\n'+
+    ';'
 });
 

--- a/test/integration/test-braces.js
+++ b/test/integration/test-braces.js
@@ -93,7 +93,7 @@ helper.test({
     '}'
 });
 
-helper.test(true, {
+helper.test({
   description:
     'if/else indentation test',
   options: { braces: '{\n' },

--- a/test/integration/test-braces.js
+++ b/test/integration/test-braces.js
@@ -20,8 +20,7 @@ helper.test({
   input:
     'function(){var foo="bar";}',
   expected:
-    'function(){\nvar foo="bar";\n' +
-    '}'
+    'function(){var foo="bar";}'
 });
 
 helper.test({
@@ -43,9 +42,7 @@ helper.test({
   input:
     '  \tfunction(){var foo="bar";}',
   expected:
-    '  \tfunction(){\n' +
-    'var foo="bar";\n' +
-    '  \t}'
+    '  \tfunction(){var foo="bar";}'
 });
 
 helper.test({
@@ -63,7 +60,7 @@ helper.test({
     '}'
 });
 
-helper.test({
+helper.test(true, {
   description:
     'More complex brace test with spacing',
   options:
@@ -71,14 +68,11 @@ helper.test({
   input:
     'var func = function()\n' +
     '\n'+
-    '  {  /*what*/  switch(foo)  {  case "foo":if(){if(){}}}};',
+    '  {  /*what*/  switch(foo)  {  case "foo":if(){if(){}}}' +
+    '\n};',
   expected:
     'var func = function(){\n' +
-    '  /*what*/  switch(foo){\n' + 
-    '  case "foo":if(){\n' +
-    'if(){}\n'+
-    '}\n'+
-    '}\n'+
+    '  /*what*/  switch(foo)  {  case "foo":if(){if(){}}}\n'+
     '};'
 });
 

--- a/test/integration/test-braces.js
+++ b/test/integration/test-braces.js
@@ -76,21 +76,37 @@ helper.test({
     '};'
 });
 
-helper.test( {
-    description:
-      'Try/catch test',
-    options: {
-  braces: '{\n'
-    },
+helper.test({
+  description:
+    'Try/catch test',
+  options: { braces: '{\n' },
   input:
     'try {\n' +
     '    var foo = bar;\n' +
     '} catch (err) {\n' +
     '}',
   expected:
-  'try{\n' +
-  '    var foo = bar;\n' +
-  '} catch (err){\n' +
-  '\n' +
-  '}',
+    'try{\n' +
+    '    var foo = bar;\n' +
+    '} catch (err){\n' +
+    '\n' +
+    '}'
+});
+
+helper.test(true, {
+  description:
+    'if/else indentation test',
+  options: { braces: '{\n' },
+  input:
+    '  if (foo){\n' +
+    '    bar=baz;\n' +
+    '  } else{\n' + 
+    '    baz=bar;\n' +
+    '  }',
+  expected:
+    '  if (foo){\n' +
+    '    bar=baz;\n' +
+    '  } else{\n' + 
+    '    baz=bar;\n' +
+    '  }',
 });

--- a/test/integration/test-braces.js
+++ b/test/integration/test-braces.js
@@ -45,14 +45,14 @@ helper.test({
     'function(){\nvar foo="bar";\n}\n'
 });
 
-//helper.test({
-//  description:
-//    'More complex brace test with spacing',
-//  options:
-//    {braces: "knr"},
-//  input:
-//    'var func = function()\n\n  {  /*what*/  switch(foo)  {  case "foo":if(){if(){}}}};',
-//  expected:
-//    'var func = function(){\n/*what*/  switch(foo){\ncase "foo":if(){\nif(){}}}};'
-//});
+helper.test({
+  description:
+    'More complex brace test with spacing',
+  options:
+    {braces: "knr"},
+  input:
+    'var func = function()\n\n  {  /*what*/  switch(foo)  {  case "foo":if(){if(){}}}};',
+  expected:
+    'var func = function(){\n/*what*/  switch(foo){\ncase "foo":if(){\nif(){}\n}\n\n}\n\n}\n;'
+});
 

--- a/test/integration/test-braces.js
+++ b/test/integration/test-braces.js
@@ -45,7 +45,7 @@ helper.test({
     '  \tfunction(){var foo="bar";}',
   expected:
     '  \tfunction(){\n' +
-    '  \tvar foo="bar";\n' +
+    'var foo="bar";\n' +
     '  \t}'
 });
 
@@ -60,7 +60,7 @@ helper.test({
     '\t var foo="bar";}',
   expected:
     'function(){\n'+
-    'var foo="bar";\n' +
+    '\t var foo="bar";\n' +
     '}'
 });
 
@@ -75,8 +75,8 @@ helper.test({
     '  {  /*what*/  switch(foo)  {  case "foo":if(){if(){}}}};',
   expected:
     'var func = function(){\n' +
-    '/*what*/  switch(foo){\n' + 
-    'case "foo":if(){\n' +
+    '  /*what*/  switch(foo){\n' + 
+    '  case "foo":if(){\n' +
     'if(){}\n'+
     '}\n'+
     '}\n'+


### PR DESCRIPTION
Finally finished the braces plugin. 

You can configure `braces` with the following settings:
- `braces: "{\n"`: changes all `{` into `if(foo){`
- `braces: " {\n"`: changes all `{` into `if(foo) {` (of course you could add more spaces, but who wants that :))
- `braces: "\n{"`: changes all `{` into `if(foo)\n{`
