### PR TITLE
Reparse after each plugin execution

### DIFF
--- a/lib/syntux.js
+++ b/lib/syntux.js
@@ -22,6 +22,8 @@ Syntux.prototype.parse = function(source) {
 
 Syntux.prototype.transform = function(options) {
   for (var plugin in options) {
+    // reparse after every plugin execution (clean tree for each plugin)
+    this.parse(this.stringify());
     plugins[plugin](this._parser, options[plugin]);
   }
 };


### PR DESCRIPTION
Because nearly every plugin relies on a clean tree and also manipulates the values of a tree by e.g. adding/removing whitespace, it makes sense that the tree is rebuilt after each plugin run.
