### PR TITLE
Add spacing plugin

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -24,6 +24,8 @@ Parser.parse = function(source) {
       comment    : wtoken.name === 7 || wtoken.name === 8,
       error      : (wtoken.name === 14),
       objLiteral : !!wtoken.isObjectLiteralStart,
+      callStart  : !!wtoken.isCallExpressionStart,
+      stmtStart  : !!wtoken.statementHeaderStart,
       _zeToken  : wtoken,
     });
 
@@ -31,6 +33,7 @@ Parser.parse = function(source) {
   }
 
   this._assignTwinRefs(wtokens);
+  this._assginMethodDeclaration(wtokens);
   this._enhanceWithAst(tokens, parser.stack);
   return tokens;
 };
@@ -54,5 +57,14 @@ Parser._enhanceWithAst = function(tokens, nodes, depth) {
 Parser._assignTwinRefs = function(nodes) {
   nodes.forEach(function(node) {
     node._token.twin = node.twin ? node.twin._token : null;
+  });
+};
+
+Parser._assginMethodDeclaration = function(nodes) {
+  nodes.forEach(function(node) {
+    if(node.lhp) node.lhp._token.methodDecl = true;
+    if(node.rhp) node.rhp._token.methodDecl = true;
+    if(node.lhc) node.lhc._token.methodDecl = true;
+    if(node.rhc) node.rhc._token.methodDecl = true;
   });
 }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -24,6 +24,7 @@ Parser.parse = function(source) {
       comment    : wtoken.name === 7 || wtoken.name === 8,
       error      : (wtoken.name === 14),
       objLiteral : !!wtoken.isObjectLiteralStart,
+      unary      : !!wtoken.isUnaryOp,
       callStart  : !!wtoken.isCallExpressionStart,
       stmtStart  : !!wtoken.statementHeaderStart,
       _zeToken  : wtoken,

--- a/lib/plugins/spacing.js
+++ b/lib/plugins/spacing.js
@@ -144,6 +144,33 @@ SpacingPlugin.transform = function(tokens, type) {
         this.appendWhitespace(token);
       }
     }
+    if(token.value === '{' && token.objLiteral && !this.searchLineEnd(token) &&
+        conf.around && typeof(conf.around.braces) !== 'undefined') {
+      this.clearWhitespace(token, 'next');
+      this.clearWhitespace(token.twin, 'prev');
+      if(conf.around.braces) {
+        this.appendWhitespace(token);
+        this.prependWhitespace(token.twin);
+      }
+    }
+    if(token.value === '[' && !this.searchLineEnd(token) &&
+        conf.around && typeof(conf.around.brackets) !== 'undefined') {
+      this.clearWhitespace(token, 'next');
+      this.clearWhitespace(token.twin, 'prev');
+      if(conf.around.brackets) {
+        this.appendWhitespace(token);
+        this.prependWhitespace(token.twin);
+      }
+    }
+    if(token.value === '(' && !this.searchLineEnd(token) &&
+        conf.around && typeof(conf.around.parentheses) !== 'undefined') {
+      this.clearWhitespace(token, 'next');
+      this.clearWhitespace(token.twin, 'prev');
+      if(conf.around.parentheses) {
+        this.appendWhitespace(token);
+        this.prependWhitespace(token.twin);
+      }
+    }
   } while(token = token.next);
 };
 SpacingPlugin.presets = {
@@ -171,7 +198,7 @@ SpacingPlugin.presets = {
       'shiftOp': true,
       'braces': false,
       'brackets': false,
-      'parantheses': false
+      'parentheses': false
     }
   },
   'dojo': {
@@ -199,7 +226,7 @@ SpacingPlugin.presets = {
       'shiftOp': true,
       'braces': false,
       'brackets': false,
-      'parantheses': false
+      'parentheses': false
     }
   }
 };

--- a/lib/plugins/spacing.js
+++ b/lib/plugins/spacing.js
@@ -15,153 +15,77 @@ SpacingPlugin.transform = function(tokens, type) {
   
   do {
     // before spacing
+    var spacing = {
+      before: {
+        methodDeclaration: token.value === '(' && token.methodDecl,
+        methodCall: token.callStart,
+        statement: token.stmtStart,
+        braces: token.value === '{' && !token.objLiteral,
+        caseColon: token.value === ':' && this.isCaseColon(token)
+      },
+      after: {
+        comma: token.value === ',',
+        semicolon: token.value === ';',
+        logicalNot: token.value === '!' && token.next && token.next.value !== '!'
+      },
+      around: {
+        assignmentOp: assignmentOps.indexOf(token.value) != -1,
+        logicalOp: logicalOps.indexOf(token.value) != -1,
+        relationalOp: relationalOps.indexOf(token.value) != -1,
+        equalOp: equalOps.indexOf(token.value) != -1,
+        bitwiseOp: bitwiseOps.indexOf(token.value) != -1,
+        condOp: token.value === '?' || (token.value === ':' && this.isConditionalOp(token)),
+        mathOp: mathOps.indexOf(token.value) != -1 && !token.unary,
+        shiftOp: shiftOps.indexOf(token.value) != -1,
+        braces: token.value === '{' && token.objLiteral,
+        brackets: token.value === '[',
+        parentheses: token.value === '('
+      }
+    }
+    var key, condition;
     if(conf.before && !this.searchLineStart(token)) {
-      if(token.value === '(' && token.methodDecl && typeof(conf.before.methodDeclaration) !== 'undefined') {
-        this.clearWhitespace(token, 'prev');
-        if(conf.before.methodDeclaration) {
-          token.value = ' (';
-        }
-      }
-      if(token.callStart && typeof(conf.before.methodCall) !== 'undefined') {
-        this.clearWhitespace(token, 'prev');
-        if(conf.before.methodCall) {
-          this.prependWhitespace(token);
-        }
-      }
-      if(token.stmtStart && typeof(conf.before.statement) !== 'undefined') {
-        this.clearWhitespace(token, 'prev');
-        if(conf.before.statement) {
-          this.prependWhitespace(token);
-        }
-      }
-      if(token.value === '{' && !token.objLiteral && typeof(conf.before.braces) !== 'undefined') {
-        this.clearWhitespace(token, 'prev');
-        if(conf.before.braces) {
-          this.prependWhitespace(token);
-        }
-      }
-      if(token.value === ':' && this.isCaseColon(token) && typeof(conf.before.caseColon) !== 'undefined') {
-        this.clearWhitespace(token, 'prev');
-        if(conf.before.caseColon) {
-          this.prependWhitespace(token);
+      for(key in spacing.before) {
+        condition = spacing.before[key]
+        if(condition && typeof(conf.before[key]) !== 'undefined') {
+          this.clearWhitespace(token, 'prev');
+          if(conf.before[key]) {
+            this.prependWhitespace(token);
+          }
         }
       }
     }
     
-    // after spacing
     if(conf.after && !this.searchLineEnd(token)) {
-      if(token.value === ',' && typeof(conf.after.comma) !== 'undefined') {
-        this.clearWhitespace(token, 'next');
-        if(conf.after.comma) {
-          this.appendWhitespace(token);
-        }
-      }
-      if(token.value === ';' && typeof(conf.after.semicolon) !== 'undefined') {
-        var foo = token;
-        this.clearWhitespace(token, 'next');
-        if(conf.after.semicolon) {
-          this.appendWhitespace(token);
-        }
-      }
-      if(token.value === '!' && token.next && token.next.value !== '!' &&
-          typeof(conf.after.logicalNot) !== 'undefined') {
-        this.clearWhitespace(token, 'next');
-        if(conf.after.logicalNot) {
-          this.appendWhitespace(token);
+      for(key in spacing.after) {
+        condition = spacing.after[key];
+        if(condition && typeof(conf.after[key]) !== 'undefined') {
+          this.clearWhitespace(token, 'next');
+          if(conf.after[key]) {
+            this.appendWhitespace(token);
+          }
         }
       }
     }
     
-    // before spacing
     if(conf.around && !(this.searchLineStart(token) || this.searchLineEnd(token))) {
-      if(assignmentOps.indexOf(token.value) != -1 && typeof(conf.around.assignmentOp) !== 'undefined') {
-        this.clearWhitespace(token, 'prev');
-        this.clearWhitespace(token, 'next');
-        if(conf.around.assignmentOp) {
-          this.prependWhitespace(token);
-          this.appendWhitespace(token);
-        }
-      }
-      if(logicalOps.indexOf(token.value) != -1 && typeof(conf.around.logicalOp) !== 'undefined') {
-        this.clearWhitespace(token, 'prev');
-        this.clearWhitespace(token, 'next');
-        if(conf.around.logicalOp) {
-          this.prependWhitespace(token);
-          this.appendWhitespace(token);
-        }
-      }
-      if(relationalOps.indexOf(token.value) != -1 && typeof(conf.around.relationalOp) !== 'undefined') {
-        this.clearWhitespace(token, 'prev');
-        this.clearWhitespace(token, 'next');
-        if(conf.around.relationalOp) {
-          this.prependWhitespace(token);
-          this.appendWhitespace(token);
-        }
-      }
-      if(equalOps.indexOf(token.value) != -1 && typeof(conf.around.equalOp) !== 'undefined') {
-        this.clearWhitespace(token, 'prev');
-        this.clearWhitespace(token, 'next');
-        if(conf.around.equalOp) {
-          this.prependWhitespace(token);
-          this.appendWhitespace(token);
-        }
-      }
-      if(bitwiseOps.indexOf(token.value) != -1 && typeof(conf.around.bitwiseOp) !== 'undefined') {
-        this.clearWhitespace(token, 'prev');
-        this.clearWhitespace(token, 'next');
-        if(conf.around.bitwiseOp) {
-          this.prependWhitespace(token);
-          this.appendWhitespace(token);
-        }
-      }
-      // TODO: differentiate from case colons
-      if((token.value === '?' || (token.value === ':' && this.isConditionalOp(token))) &&
-          typeof(conf.around.condOp) !== 'undefined') {
-        this.clearWhitespace(token, 'prev');
-        this.clearWhitespace(token, 'next');
-        if(conf.around.condOp) {
-          this.prependWhitespace(token);
-          this.appendWhitespace(token);
-        }
-      }
-      if(mathOps.indexOf(token.value) != -1 && !token.unary && typeof(conf.around.mathOp) !== 'undefined') {
-        this.clearWhitespace(token, 'prev');
-        this.clearWhitespace(token, 'next');
-        if(conf.around.mathOp) {
-          this.prependWhitespace(token);
-          this.appendWhitespace(token);
-        }
-      }
-      if(shiftOps.indexOf(token.value) != -1 && typeof(conf.around.shiftOp) !== 'undefined') {
-        this.clearWhitespace(token, 'prev');
-        this.clearWhitespace(token, 'next');
-        if(conf.around.shiftOp) {
-          this.prependWhitespace(token);
-          this.appendWhitespace(token);
-        }
-      }
-      if(token.value === '{' && token.objLiteral && typeof(conf.around.braces) !== 'undefined') {
-        this.clearWhitespace(token, 'next');
-        this.clearWhitespace(token.twin, 'prev');
-        if(conf.around.braces) {
-          this.appendWhitespace(token);
-          this.prependWhitespace(token.twin);
-        }
-      }
-      if(token.value === '[' && typeof(conf.around.brackets) !== 'undefined') {
-        this.clearWhitespace(token, 'next');
-        this.clearWhitespace(token.twin, 'prev');
-        if(conf.around.brackets) {
-          this.appendWhitespace(token);
-          this.prependWhitespace(token.twin);
-        }
-      }
-      if(token.value === '(' && typeof(conf.around.parentheses) !== 'undefined') {
-        this.clearWhitespace(token, 'next');
-        this.clearWhitespace(token.twin, 'prev');
-        if(conf.around.parentheses) {
-          this.appendWhitespace(token);
-          this.prependWhitespace(token.twin);
+      for(key in spacing.around) {
+        condition = spacing.around[key];
+        if(condition && typeof(conf.around[key]) !== 'undefined') {
+          if(key === 'braces' || key === 'brackets' || key === 'parentheses') {
+            this.clearWhitespace(token, 'next');
+            this.clearWhitespace(token.twin, 'prev');
+            if(conf.around[key]) {
+              this.appendWhitespace(token);
+              this.prependWhitespace(token.twin);
+            }
+          } else {
+            this.clearWhitespace(token, 'prev');
+            this.clearWhitespace(token, 'next');
+            if(conf.around[key]) {
+              this.appendWhitespace(token);
+              this.prependWhitespace(token);
+            }
+          }
         }
       }
     }

--- a/lib/plugins/spacing.js
+++ b/lib/plugins/spacing.js
@@ -17,7 +17,6 @@ SpacingPlugin.transform = function(tokens, type) {
   var shiftOps = ['<<', '>>', '>>>'];
   
   do {
-    // before spacing
     spacingConds = {
       before: {
         methodDeclaration: token.value === '(' && token.methodDecl,
@@ -46,6 +45,7 @@ SpacingPlugin.transform = function(tokens, type) {
       }
     }
 
+    // before spacing
     if(conf.before && !this.isAtLineStart(token)) {
       for(key in spacingConds.before) {
         condition = spacingConds.before[key]
@@ -58,6 +58,7 @@ SpacingPlugin.transform = function(tokens, type) {
       }
     }
 
+    // after spacing
     if(conf.after && !this.isAtLineEnd(token)) {
       for(key in spacingConds.after) {
         condition = spacingConds.after[key];
@@ -69,7 +70,8 @@ SpacingPlugin.transform = function(tokens, type) {
         }
       }
     }
-
+    
+    // around spacing
     if(conf.around && !(this.isAtLineStart(token) || this.isAtLineEnd(token))) {
       for(key in spacingConds.around) {
         condition = spacingConds.around[key];
@@ -92,6 +94,7 @@ SpacingPlugin.transform = function(tokens, type) {
         }
       }
     }
+
   } while(token = token.next);
 };
 SpacingPlugin.presets = {

--- a/lib/plugins/spacing.js
+++ b/lib/plugins/spacing.js
@@ -1,5 +1,8 @@
 var SpacingPlugin = module.exports = {};
 SpacingPlugin.transform = function(tokens, type) {
+  var condition;
+  var key;
+  var spacingConds;
   var conf = typeof(type) === 'object' ? type : this.presets[type];
   var token = tokens.first;
   var assignmentOps = [
@@ -15,7 +18,7 @@ SpacingPlugin.transform = function(tokens, type) {
   
   do {
     // before spacing
-    var spacing = {
+    spacingConds = {
       before: {
         methodDeclaration: token.value === '(' && token.methodDecl,
         methodCall: token.callStart,
@@ -42,10 +45,10 @@ SpacingPlugin.transform = function(tokens, type) {
         parentheses: token.value === '('
       }
     }
-    var key, condition;
+
     if(conf.before && !this.isAtLineStart(token)) {
-      for(key in spacing.before) {
-        condition = spacing.before[key]
+      for(key in spacingConds.before) {
+        condition = spacingConds.before[key]
         if(condition && typeof(conf.before[key]) !== 'undefined') {
           this.clearWhitespace(token, 'prev');
           if(conf.before[key]) {
@@ -54,10 +57,10 @@ SpacingPlugin.transform = function(tokens, type) {
         }
       }
     }
-    
+
     if(conf.after && !this.isAtLineEnd(token)) {
-      for(key in spacing.after) {
-        condition = spacing.after[key];
+      for(key in spacingConds.after) {
+        condition = spacingConds.after[key];
         if(condition && typeof(conf.after[key]) !== 'undefined') {
           this.clearWhitespace(token, 'next');
           if(conf.after[key]) {
@@ -66,10 +69,10 @@ SpacingPlugin.transform = function(tokens, type) {
         }
       }
     }
-    
+
     if(conf.around && !(this.isAtLineStart(token) || this.isAtLineEnd(token))) {
-      for(key in spacing.around) {
-        condition = spacing.around[key];
+      for(key in spacingConds.around) {
+        condition = spacingConds.around[key];
         if(condition && typeof(conf.around[key]) !== 'undefined') {
           if(key === 'braces' || key === 'brackets' || key === 'parentheses') {
             this.clearWhitespace(token, 'next');

--- a/lib/plugins/spacing.js
+++ b/lib/plugins/spacing.js
@@ -154,24 +154,30 @@ SpacingPlugin.presets = {
 
 SpacingPlugin.clearWhitespace = function(token, direction) {
   while((token = token[direction]) && (token.white || token.newLine)) {
-    token.remove();
+    if(! token.comment) {
+      token.remove();
+    }
   };
 };
 
 SpacingPlugin.prependWhitespace = function(token) {
-  token.prepend({
-    value: ' ',
-    white: true,
-    depth: token.depth
-  });
+  do {
+    token.prepend({
+      value: ' ',
+      white: true,
+      depth: token.depth
+    });
+  } while((token = token.prev.prev) && token.comment);
 };
 
 SpacingPlugin.appendWhitespace = function(token) {
-  token.append({
-    value: ' ',
-    white: true,
-    depth: token.depth
-  });
+  do {
+    token.append({
+      value: ' ',
+      white: true,
+      depth: token.depth
+    });
+  } while((token = token.next.next) && token.comment);
 };
 
 SpacingPlugin.isCaseColon = function(token) {

--- a/lib/plugins/spacing.js
+++ b/lib/plugins/spacing.js
@@ -10,7 +10,6 @@ SpacingPlugin.transform = function(tokens, type) {
   var relationalOps = ['<', '>', '<=', '>=', 'instanceof', 'in'];
   var equalOps = ['==', '!=', '===', '!=='];
   var bitwiseOps = ['&', '^', '|'];
-  var condOps = ['?', ':'];
   var mathOps = ['+', '-', '/', '*', '%'];
   var shiftOps = ['<<', '>>', '>>>'];
   
@@ -71,8 +70,8 @@ SpacingPlugin.transform = function(tokens, type) {
         this.appendWhitespace(token);
       }
     }
-    if(assignmentOps.indexOf(token.value) != -1 && conf.around 
-        && typeof(conf.around.assignmentOp) !== 'undefined') {
+    if(assignmentOps.indexOf(token.value) != -1 && conf.around && !this.searchLineEnd(token) &&
+        typeof(conf.around.assignmentOp) !== 'undefined') {
       this.clearWhitespace(token, 'prev');
       this.clearWhitespace(token, 'next');
       if(conf.around.assignmentOp) {
@@ -80,8 +79,8 @@ SpacingPlugin.transform = function(tokens, type) {
         this.appendWhitespace(token);
       }
     }
-    if(logicalOps.indexOf(token.value) != -1 && conf.around 
-        && typeof(conf.around.logicalOp) !== 'undefined') {
+    if(logicalOps.indexOf(token.value) != -1 && conf.around && !this.searchLineEnd(token) &&
+        typeof(conf.around.logicalOp) !== 'undefined') {
       this.clearWhitespace(token, 'prev');
       this.clearWhitespace(token, 'next');
       if(conf.around.logicalOp) {
@@ -89,8 +88,8 @@ SpacingPlugin.transform = function(tokens, type) {
         this.appendWhitespace(token);
       }
     }
-    if(relationalOps.indexOf(token.value) != -1 && conf.around 
-        && typeof(conf.around.relationalOp) !== 'undefined') {
+    if(relationalOps.indexOf(token.value) != -1 && conf.around && !this.searchLineEnd(token) &&
+        typeof(conf.around.relationalOp) !== 'undefined') {
       this.clearWhitespace(token, 'prev');
       this.clearWhitespace(token, 'next');
       if(conf.around.relationalOp) {
@@ -98,8 +97,8 @@ SpacingPlugin.transform = function(tokens, type) {
         this.appendWhitespace(token);
       }
     }
-    if(equalOps.indexOf(token.value) != -1 && conf.around 
-        && typeof(conf.around.equalOp) !== 'undefined') {
+    if(equalOps.indexOf(token.value) != -1 && conf.around && !this.searchLineEnd(token) &&
+        typeof(conf.around.equalOp) !== 'undefined') {
       this.clearWhitespace(token, 'prev');
       this.clearWhitespace(token, 'next');
       if(conf.around.equalOp) {
@@ -107,8 +106,8 @@ SpacingPlugin.transform = function(tokens, type) {
         this.appendWhitespace(token);
       }
     }
-    if(bitwiseOps.indexOf(token.value) != -1 && conf.around 
-        && typeof(conf.around.bitwiseOp) !== 'undefined') {
+    if(bitwiseOps.indexOf(token.value) != -1 && conf.around && !this.searchLineEnd(token) &&
+        typeof(conf.around.bitwiseOp) !== 'undefined') {
       this.clearWhitespace(token, 'prev');
       this.clearWhitespace(token, 'next');
       if(conf.around.bitwiseOp) {
@@ -126,8 +125,8 @@ SpacingPlugin.transform = function(tokens, type) {
         this.appendWhitespace(token);
       }
     }
-    if(mathOps.indexOf(token.value) != -1 && conf.around 
-        && typeof(conf.around.mathOp) !== 'undefined') {
+    if(mathOps.indexOf(token.value) != -1 && conf.around && !this.searchLineEnd(token) &&
+        !token.unary && typeof(conf.around.mathOp) !== 'undefined') {
       this.clearWhitespace(token, 'prev');
       this.clearWhitespace(token, 'next');
       if(conf.around.mathOp) {
@@ -135,8 +134,8 @@ SpacingPlugin.transform = function(tokens, type) {
         this.appendWhitespace(token);
       }
     }
-    if(shiftOps.indexOf(token.value) != -1 && conf.around 
-        && typeof(conf.around.shiftOp) !== 'undefined') {
+    if(shiftOps.indexOf(token.value) != -1 && conf.around && !this.searchLineEnd(token) &&
+        typeof(conf.around.shiftOp) !== 'undefined') {
       this.clearWhitespace(token, 'prev');
       this.clearWhitespace(token, 'next');
       if(conf.around.shiftOp) {

--- a/lib/plugins/spacing.js
+++ b/lib/plugins/spacing.js
@@ -43,7 +43,7 @@ SpacingPlugin.transform = function(tokens, type) {
       }
     }
     var key, condition;
-    if(conf.before && !this.searchLineStart(token)) {
+    if(conf.before && !this.isAtLineStart(token)) {
       for(key in spacing.before) {
         condition = spacing.before[key]
         if(condition && typeof(conf.before[key]) !== 'undefined') {
@@ -55,7 +55,7 @@ SpacingPlugin.transform = function(tokens, type) {
       }
     }
     
-    if(conf.after && !this.searchLineEnd(token)) {
+    if(conf.after && !this.isAtLineEnd(token)) {
       for(key in spacing.after) {
         condition = spacing.after[key];
         if(condition && typeof(conf.after[key]) !== 'undefined') {
@@ -67,7 +67,7 @@ SpacingPlugin.transform = function(tokens, type) {
       }
     }
     
-    if(conf.around && !(this.searchLineStart(token) || this.searchLineEnd(token))) {
+    if(conf.around && !(this.isAtLineStart(token) || this.isAtLineEnd(token))) {
       for(key in spacing.around) {
         condition = spacing.around[key];
         if(condition && typeof(conf.around[key]) !== 'undefined') {
@@ -197,9 +197,9 @@ SpacingPlugin.isConditionalOp = function(token) {
   return false;
 };
 
-SpacingPlugin.searchLineEnd = function(token) {
+SpacingPlugin.isAtLineStart = function(token) {
   var origToken = token;
-  while((token = token.next) && (token.white || token.lineEnd)) {
+  while((token = token.prev) && (token.white || token.lineEnd)) {
     if(token.lineEnd) {
       return true;
     }
@@ -208,9 +208,9 @@ SpacingPlugin.searchLineEnd = function(token) {
   return false;
 };
 
-SpacingPlugin.searchLineStart = function(token) {
+SpacingPlugin.isAtLineEnd = function(token) {
   var origToken = token;
-  while((token = token.prev) && (token.white || token.lineEnd)) {
+  while((token = token.next) && (token.white || token.lineEnd)) {
     if(token.lineEnd) {
       return true;
     }

--- a/lib/plugins/spacing.js
+++ b/lib/plugins/spacing.js
@@ -1,0 +1,167 @@
+var SpacingPlugin = module.exports = {};
+SpacingPlugin.transform = function(tokens, type) {
+  var conf = typeof(type) === 'object' ? type : this.config[type];
+  var token = tokens.first;
+  
+  do {
+    if(token.value === '(' && token.methodDecl &&
+        typeof(conf.before.methodDeclaration) !== 'undefined') {
+      this.clearWhitespace(token, 'prev');
+      if(conf.before.methodDeclaration) {
+        token.value = ' (';
+      }
+    }
+    if(token.callStart && conf.before && typeof(conf.before.methodCall) !== 'undefined') {
+      this.clearWhitespace(token, 'prev');
+      if(conf.before.methodCall) {
+        this.prependWhitespace(token);
+      }
+    }
+    if(token.stmtStart && conf.before &&
+        typeof(conf.before.statement) !== 'undefined') {
+      this.clearWhitespace(token, 'prev');
+      if(conf.before.statement) {
+        this.prependWhitespace(token);
+      }
+    }
+    if(token.value === '{' && !token.objLiteral && conf.before &&
+        typeof(conf.before.braces) !== 'undefined') {
+      this.clearWhitespace(token, 'prev');
+      if(conf.before.braces) {
+        this.prependWhitespace(token);
+      }
+    }
+    if(token.value === ':' && this.isCaseColon(token) && conf.before &&
+        typeof(conf.before.caseColon) !== 'undefined') {
+      this.clearWhitespace(token, 'prev');
+      if(conf.before.caseColon) {
+        this.prependWhitespace(token);
+      }
+    }
+    // TODO: token.next.lineEnd is maybe not sufficient
+    if(token.value === ',' && conf.after && !this.searchLineEnd(token) &&
+        typeof(conf.after.comma) !== 'undefined') {
+      this.clearWhitespace(token, 'next');
+      if(conf.after.comma) {
+        this.appendWhitespace(token);
+      }
+    }
+    // TODO: token.next.lineEnd is maybe not sufficient
+    if(token.value === ';' && conf.after && !this.searchLineEnd(token) &&
+        typeof(conf.after.semicolon) !== 'undefined') {
+      var foo = token;
+      this.clearWhitespace(token, 'next');
+      if(conf.after.semicolon) {
+        this.appendWhitespace(token);
+      }
+    }
+    if(token.value === '!' && conf.after && token.next && token.next.value !== '!' &&
+        typeof(conf.after.logicalNot) !== 'undefined') {
+      this.clearWhitespace(token, 'next');
+      if(conf.after.logicalNot) {
+        this.appendWhitespace(token);
+      }
+    }
+  } while(token = token.next);
+};
+SpacingPlugin.config = {
+  'node': {
+    'before': {
+      'methodDeclaration': false,
+      'methodCall': false,
+      'statement': true,
+      'braces': true,
+      'caseColon': false
+    },
+    'after': {
+      'comma': true,
+      'semicolon': true,
+      'logicalNot': false
+    },
+    'around': {
+      'assignmentOp': true,
+      'logicalOp': true,
+      'relationalOp': true,
+      'bitwiseOp': true,
+      'conditionalOp': true,
+      'mathOp': true,
+      'shiftOp': true,
+      'braces': false,
+      'brackets': false,
+      'parantheses': false
+    }
+  },
+  'dojo': {
+    'before': {
+      'methodDeclaration': false,
+      'methodCall': false,
+      'statement': false,
+      'braces': false,
+      'brackets': false,
+      'caseColon': false
+    },
+    'after': {
+      'comma': true,
+      'semicolon': true,
+      'logicalNot': false
+    },
+    'around': {
+      'assignmentOp': true,
+      'logicalOp': true,
+      'relationalOp': true,
+      'bitwiseOp': true,
+      'conditionalOp': true,
+      'mathOp': true,
+      'shiftOp': true,
+      'braces': false,
+      'brackets': false,
+      'parantheses': false
+    }
+  }
+};
+
+SpacingPlugin.clearWhitespace = function(token, direction) {
+  while((token = token[direction]) && (token.white || token.newLine)) {
+    token.remove();
+  };
+};
+
+SpacingPlugin.prependWhitespace = function(token) {
+  token.prepend({
+    value: ' ',
+    white: true,
+    depth: token.depth
+  });
+};
+
+SpacingPlugin.appendWhitespace = function(token) {
+  token.append({
+    value: ' ',
+    white: true,
+    depth: token.depth
+  });
+};
+
+SpacingPlugin.isCaseColon = function(token) {
+  var origToken = token;
+  while(token = token.prev) {
+    if(token.value === 'case' && token.depth === origToken.depth) {
+      return true;
+    }
+    if(token.depth < origToken.depth) {
+      return false;
+    }
+  };
+  return false;
+}
+
+SpacingPlugin.searchLineEnd = function(token) {
+  var origToken = token;
+  while((token = token.next) && (token.white || token.lineEnd)) {
+    if(token.lineEnd) {
+      return true;
+    }
+  }
+  if(token === null) return true;
+  return false;
+}

--- a/lib/plugins/spacing.js
+++ b/lib/plugins/spacing.js
@@ -152,6 +152,33 @@ SpacingPlugin.presets = {
       'brackets': false,
       'parentheses': false
     }
+  },
+  'jquery': {
+    'before': {
+      'methodDeclaration': false,
+      'methodCall': false,
+      'statement': false,
+      'braces': false,
+      'caseColon': false
+    },
+    'after': {
+      'comma': true,
+      'semicolon': true,
+      'logicalNot': false
+    },
+    'around': {
+      'assignmentOp': true,
+      'logicalOp': true,
+      'relationalOp': true,
+      'equalOps': true,
+      'bitwiseOp': true,
+      'condOp': true,
+      'mathOp': true,
+      'shiftOp': true,
+      'braces': false,
+      'brackets': true,
+      'parentheses': true
+    }
   }
 };
 

--- a/lib/plugins/spacing.js
+++ b/lib/plugins/spacing.js
@@ -14,34 +14,35 @@ SpacingPlugin.transform = function(tokens, type) {
   var shiftOps = ['<<', '>>', '>>>'];
   
   do {
-    if(token.value === '(' && token.methodDecl &&
+    if(token.value === '(' && token.methodDecl && !this.searchLineStart(token) &&
         typeof(conf.before.methodDeclaration) !== 'undefined') {
       this.clearWhitespace(token, 'prev');
       if(conf.before.methodDeclaration) {
         token.value = ' (';
       }
     }
-    if(token.callStart && conf.before && typeof(conf.before.methodCall) !== 'undefined') {
+    if(token.callStart && conf.before && !this.searchLineStart(token) && 
+        typeof(conf.before.methodCall) !== 'undefined') {
       this.clearWhitespace(token, 'prev');
       if(conf.before.methodCall) {
         this.prependWhitespace(token);
       }
     }
-    if(token.stmtStart && conf.before &&
+    if(token.stmtStart && conf.before && !this.searchLineStart(token) &&
         typeof(conf.before.statement) !== 'undefined') {
       this.clearWhitespace(token, 'prev');
       if(conf.before.statement) {
         this.prependWhitespace(token);
       }
     }
-    if(token.value === '{' && !token.objLiteral && conf.before &&
+    if(token.value === '{' && !token.objLiteral && conf.before && !this.searchLineStart(token) &&
         typeof(conf.before.braces) !== 'undefined') {
       this.clearWhitespace(token, 'prev');
       if(conf.before.braces) {
         this.prependWhitespace(token);
       }
     }
-    if(token.value === ':' && this.isCaseColon(token) && conf.before &&
+    if(token.value === ':' && this.isCaseColon(token) && conf.before && !this.searchLineStart(token) &&
         typeof(conf.before.caseColon) !== 'undefined') {
       this.clearWhitespace(token, 'prev');
       if(conf.before.caseColon) {
@@ -280,7 +281,18 @@ SpacingPlugin.isConditionalOp = function(token) {
 
 SpacingPlugin.searchLineEnd = function(token) {
   var origToken = token;
-  while((token = token.next) && (token.white || token.lineEnd)) {
+  while((token = token.next) && (!token.comment && (token.white || token.lineEnd))) {
+    if(token.lineEnd) {
+      return true;
+    }
+  }
+  if(token === null) return true;
+  return false;
+};
+
+SpacingPlugin.searchLineStart = function(token) {
+  var origToken = token;
+  while((token = token.prev) && (!token.comment && (token.white || token.lineEnd))) {
     if(token.lineEnd) {
       return true;
     }

--- a/lib/plugins/spacing.js
+++ b/lib/plugins/spacing.js
@@ -117,8 +117,8 @@ SpacingPlugin.transform = function(tokens, type) {
       }
     }
     // TODO: differentiate from case colons
-    if(condOps.indexOf(token.value) != -1 && conf.around 
-        && typeof(conf.around.condOp) !== 'undefined') {
+    if((token.value === '?' || (token.value === ':' && this.isConditionalOp(token))) && !this.searchLineEnd(token) &&
+        conf.around && typeof(conf.around.condOp) !== 'undefined') {
       this.clearWhitespace(token, 'prev');
       this.clearWhitespace(token, 'next');
       if(conf.around.condOp) {
@@ -257,6 +257,19 @@ SpacingPlugin.isCaseColon = function(token) {
   var origToken = token;
   while(token = token.prev) {
     if(token.value === 'case' && token.depth === origToken.depth) {
+      return true;
+    }
+    if(token.depth < origToken.depth) {
+      return false;
+    }
+  };
+  return false;
+};
+
+SpacingPlugin.isConditionalOp = function(token) {
+  var origToken = token;
+  while(token = token.prev) {
+    if(token.value === '?' && token.depth === origToken.depth) {
       return true;
     }
     if(token.depth < origToken.depth) {

--- a/lib/plugins/spacing.js
+++ b/lib/plugins/spacing.js
@@ -157,8 +157,8 @@ SpacingPlugin.presets = {
     'before': {
       'methodDeclaration': false,
       'methodCall': false,
-      'statement': false,
-      'braces': false,
+      'statement': true,
+      'braces': true,
       'caseColon': false
     },
     'after': {

--- a/lib/plugins/spacing.js
+++ b/lib/plugins/spacing.js
@@ -281,7 +281,7 @@ SpacingPlugin.isConditionalOp = function(token) {
 
 SpacingPlugin.searchLineEnd = function(token) {
   var origToken = token;
-  while((token = token.next) && (!token.comment && (token.white || token.lineEnd))) {
+  while((token = token.next) && (token.white || token.lineEnd)) {
     if(token.lineEnd) {
       return true;
     }
@@ -292,7 +292,7 @@ SpacingPlugin.searchLineEnd = function(token) {
 
 SpacingPlugin.searchLineStart = function(token) {
   var origToken = token;
-  while((token = token.prev) && (!token.comment && (token.white || token.lineEnd))) {
+  while((token = token.prev) && (token.white || token.lineEnd)) {
     if(token.lineEnd) {
       return true;
     }

--- a/lib/plugins/spacing.js
+++ b/lib/plugins/spacing.js
@@ -175,7 +175,7 @@ SpacingPlugin.presets = {
       'condOp': true,
       'mathOp': true,
       'shiftOp': true,
-      'braces': false,
+      'braces': true,
       'brackets': true,
       'parentheses': true
     }

--- a/lib/plugins/spacing.js
+++ b/lib/plugins/spacing.js
@@ -79,7 +79,7 @@ SpacingPlugin.transform = function(tokens, type) {
           if(key === 'braces' || key === 'brackets' || key === 'parentheses') {
             this.clearWhitespace(token, 'next');
             this.clearWhitespace(token.twin, 'prev');
-            if(conf.around[key]) {
+            if(conf.around[key] && token.next != token.twin) {
               this.appendWhitespace(token);
               this.prependWhitespace(token.twin);
             }

--- a/lib/plugins/spacing.js
+++ b/lib/plugins/spacing.js
@@ -14,161 +14,155 @@ SpacingPlugin.transform = function(tokens, type) {
   var shiftOps = ['<<', '>>', '>>>'];
   
   do {
-    if(token.value === '(' && token.methodDecl && !this.searchLineStart(token) &&
-        typeof(conf.before.methodDeclaration) !== 'undefined') {
-      this.clearWhitespace(token, 'prev');
-      if(conf.before.methodDeclaration) {
-        token.value = ' (';
+    // before spacing
+    if(conf.before && !this.searchLineStart(token)) {
+      if(token.value === '(' && token.methodDecl && typeof(conf.before.methodDeclaration) !== 'undefined') {
+        this.clearWhitespace(token, 'prev');
+        if(conf.before.methodDeclaration) {
+          token.value = ' (';
+        }
+      }
+      if(token.callStart && typeof(conf.before.methodCall) !== 'undefined') {
+        this.clearWhitespace(token, 'prev');
+        if(conf.before.methodCall) {
+          this.prependWhitespace(token);
+        }
+      }
+      if(token.stmtStart && typeof(conf.before.statement) !== 'undefined') {
+        this.clearWhitespace(token, 'prev');
+        if(conf.before.statement) {
+          this.prependWhitespace(token);
+        }
+      }
+      if(token.value === '{' && !token.objLiteral && typeof(conf.before.braces) !== 'undefined') {
+        this.clearWhitespace(token, 'prev');
+        if(conf.before.braces) {
+          this.prependWhitespace(token);
+        }
+      }
+      if(token.value === ':' && this.isCaseColon(token) && typeof(conf.before.caseColon) !== 'undefined') {
+        this.clearWhitespace(token, 'prev');
+        if(conf.before.caseColon) {
+          this.prependWhitespace(token);
+        }
       }
     }
-    if(token.callStart && conf.before && !this.searchLineStart(token) && 
-        typeof(conf.before.methodCall) !== 'undefined') {
-      this.clearWhitespace(token, 'prev');
-      if(conf.before.methodCall) {
-        this.prependWhitespace(token);
+    
+    // after spacing
+    if(conf.after && !this.searchLineEnd(token)) {
+      if(token.value === ',' && typeof(conf.after.comma) !== 'undefined') {
+        this.clearWhitespace(token, 'next');
+        if(conf.after.comma) {
+          this.appendWhitespace(token);
+        }
+      }
+      if(token.value === ';' && typeof(conf.after.semicolon) !== 'undefined') {
+        var foo = token;
+        this.clearWhitespace(token, 'next');
+        if(conf.after.semicolon) {
+          this.appendWhitespace(token);
+        }
+      }
+      if(token.value === '!' && token.next && token.next.value !== '!' &&
+          typeof(conf.after.logicalNot) !== 'undefined') {
+        this.clearWhitespace(token, 'next');
+        if(conf.after.logicalNot) {
+          this.appendWhitespace(token);
+        }
       }
     }
-    if(token.stmtStart && conf.before && !this.searchLineStart(token) &&
-        typeof(conf.before.statement) !== 'undefined') {
-      this.clearWhitespace(token, 'prev');
-      if(conf.before.statement) {
-        this.prependWhitespace(token);
+    
+    // before spacing
+    if(conf.around && !(this.searchLineStart(token) || this.searchLineEnd(token))) {
+      if(assignmentOps.indexOf(token.value) != -1 && typeof(conf.around.assignmentOp) !== 'undefined') {
+        this.clearWhitespace(token, 'prev');
+        this.clearWhitespace(token, 'next');
+        if(conf.around.assignmentOp) {
+          this.prependWhitespace(token);
+          this.appendWhitespace(token);
+        }
       }
-    }
-    if(token.value === '{' && !token.objLiteral && conf.before && !this.searchLineStart(token) &&
-        typeof(conf.before.braces) !== 'undefined') {
-      this.clearWhitespace(token, 'prev');
-      if(conf.before.braces) {
-        this.prependWhitespace(token);
+      if(logicalOps.indexOf(token.value) != -1 && typeof(conf.around.logicalOp) !== 'undefined') {
+        this.clearWhitespace(token, 'prev');
+        this.clearWhitespace(token, 'next');
+        if(conf.around.logicalOp) {
+          this.prependWhitespace(token);
+          this.appendWhitespace(token);
+        }
       }
-    }
-    if(token.value === ':' && this.isCaseColon(token) && conf.before && !this.searchLineStart(token) &&
-        typeof(conf.before.caseColon) !== 'undefined') {
-      this.clearWhitespace(token, 'prev');
-      if(conf.before.caseColon) {
-        this.prependWhitespace(token);
+      if(relationalOps.indexOf(token.value) != -1 && typeof(conf.around.relationalOp) !== 'undefined') {
+        this.clearWhitespace(token, 'prev');
+        this.clearWhitespace(token, 'next');
+        if(conf.around.relationalOp) {
+          this.prependWhitespace(token);
+          this.appendWhitespace(token);
+        }
       }
-    }
-    if(token.value === ',' && conf.after && !this.searchLineEnd(token) &&
-        typeof(conf.after.comma) !== 'undefined') {
-      this.clearWhitespace(token, 'next');
-      if(conf.after.comma) {
-        this.appendWhitespace(token);
+      if(equalOps.indexOf(token.value) != -1 && typeof(conf.around.equalOp) !== 'undefined') {
+        this.clearWhitespace(token, 'prev');
+        this.clearWhitespace(token, 'next');
+        if(conf.around.equalOp) {
+          this.prependWhitespace(token);
+          this.appendWhitespace(token);
+        }
       }
-    }
-    if(token.value === ';' && conf.after && !this.searchLineEnd(token) &&
-        typeof(conf.after.semicolon) !== 'undefined') {
-      var foo = token;
-      this.clearWhitespace(token, 'next');
-      if(conf.after.semicolon) {
-        this.appendWhitespace(token);
+      if(bitwiseOps.indexOf(token.value) != -1 && typeof(conf.around.bitwiseOp) !== 'undefined') {
+        this.clearWhitespace(token, 'prev');
+        this.clearWhitespace(token, 'next');
+        if(conf.around.bitwiseOp) {
+          this.prependWhitespace(token);
+          this.appendWhitespace(token);
+        }
       }
-    }
-    if(token.value === '!' && conf.after && token.next && token.next.value !== '!' &&
-        typeof(conf.after.logicalNot) !== 'undefined') {
-      this.clearWhitespace(token, 'next');
-      if(conf.after.logicalNot) {
-        this.appendWhitespace(token);
+      // TODO: differentiate from case colons
+      if((token.value === '?' || (token.value === ':' && this.isConditionalOp(token))) &&
+          typeof(conf.around.condOp) !== 'undefined') {
+        this.clearWhitespace(token, 'prev');
+        this.clearWhitespace(token, 'next');
+        if(conf.around.condOp) {
+          this.prependWhitespace(token);
+          this.appendWhitespace(token);
+        }
       }
-    }
-    if(assignmentOps.indexOf(token.value) != -1 && conf.around && !this.searchLineEnd(token) &&
-        typeof(conf.around.assignmentOp) !== 'undefined') {
-      this.clearWhitespace(token, 'prev');
-      this.clearWhitespace(token, 'next');
-      if(conf.around.assignmentOp) {
-        this.prependWhitespace(token);
-        this.appendWhitespace(token);
+      if(mathOps.indexOf(token.value) != -1 && !token.unary && typeof(conf.around.mathOp) !== 'undefined') {
+        this.clearWhitespace(token, 'prev');
+        this.clearWhitespace(token, 'next');
+        if(conf.around.mathOp) {
+          this.prependWhitespace(token);
+          this.appendWhitespace(token);
+        }
       }
-    }
-    if(logicalOps.indexOf(token.value) != -1 && conf.around && !this.searchLineEnd(token) &&
-        typeof(conf.around.logicalOp) !== 'undefined') {
-      this.clearWhitespace(token, 'prev');
-      this.clearWhitespace(token, 'next');
-      if(conf.around.logicalOp) {
-        this.prependWhitespace(token);
-        this.appendWhitespace(token);
+      if(shiftOps.indexOf(token.value) != -1 && typeof(conf.around.shiftOp) !== 'undefined') {
+        this.clearWhitespace(token, 'prev');
+        this.clearWhitespace(token, 'next');
+        if(conf.around.shiftOp) {
+          this.prependWhitespace(token);
+          this.appendWhitespace(token);
+        }
       }
-    }
-    if(relationalOps.indexOf(token.value) != -1 && conf.around && !this.searchLineEnd(token) &&
-        typeof(conf.around.relationalOp) !== 'undefined') {
-      this.clearWhitespace(token, 'prev');
-      this.clearWhitespace(token, 'next');
-      if(conf.around.relationalOp) {
-        this.prependWhitespace(token);
-        this.appendWhitespace(token);
+      if(token.value === '{' && token.objLiteral && typeof(conf.around.braces) !== 'undefined') {
+        this.clearWhitespace(token, 'next');
+        this.clearWhitespace(token.twin, 'prev');
+        if(conf.around.braces) {
+          this.appendWhitespace(token);
+          this.prependWhitespace(token.twin);
+        }
       }
-    }
-    if(equalOps.indexOf(token.value) != -1 && conf.around && !this.searchLineEnd(token) &&
-        typeof(conf.around.equalOp) !== 'undefined') {
-      this.clearWhitespace(token, 'prev');
-      this.clearWhitespace(token, 'next');
-      if(conf.around.equalOp) {
-        this.prependWhitespace(token);
-        this.appendWhitespace(token);
+      if(token.value === '[' && typeof(conf.around.brackets) !== 'undefined') {
+        this.clearWhitespace(token, 'next');
+        this.clearWhitespace(token.twin, 'prev');
+        if(conf.around.brackets) {
+          this.appendWhitespace(token);
+          this.prependWhitespace(token.twin);
+        }
       }
-    }
-    if(bitwiseOps.indexOf(token.value) != -1 && conf.around && !this.searchLineEnd(token) &&
-        typeof(conf.around.bitwiseOp) !== 'undefined') {
-      this.clearWhitespace(token, 'prev');
-      this.clearWhitespace(token, 'next');
-      if(conf.around.bitwiseOp) {
-        this.prependWhitespace(token);
-        this.appendWhitespace(token);
-      }
-    }
-    // TODO: differentiate from case colons
-    if((token.value === '?' || (token.value === ':' && this.isConditionalOp(token))) && !this.searchLineEnd(token) &&
-        conf.around && typeof(conf.around.condOp) !== 'undefined') {
-      this.clearWhitespace(token, 'prev');
-      this.clearWhitespace(token, 'next');
-      if(conf.around.condOp) {
-        this.prependWhitespace(token);
-        this.appendWhitespace(token);
-      }
-    }
-    if(mathOps.indexOf(token.value) != -1 && conf.around && !this.searchLineEnd(token) &&
-        !token.unary && typeof(conf.around.mathOp) !== 'undefined') {
-      this.clearWhitespace(token, 'prev');
-      this.clearWhitespace(token, 'next');
-      if(conf.around.mathOp) {
-        this.prependWhitespace(token);
-        this.appendWhitespace(token);
-      }
-    }
-    if(shiftOps.indexOf(token.value) != -1 && conf.around && !this.searchLineEnd(token) &&
-        typeof(conf.around.shiftOp) !== 'undefined') {
-      this.clearWhitespace(token, 'prev');
-      this.clearWhitespace(token, 'next');
-      if(conf.around.shiftOp) {
-        this.prependWhitespace(token);
-        this.appendWhitespace(token);
-      }
-    }
-    if(token.value === '{' && token.objLiteral && !this.searchLineEnd(token) &&
-        conf.around && typeof(conf.around.braces) !== 'undefined') {
-      this.clearWhitespace(token, 'next');
-      this.clearWhitespace(token.twin, 'prev');
-      if(conf.around.braces) {
-        this.appendWhitespace(token);
-        this.prependWhitespace(token.twin);
-      }
-    }
-    if(token.value === '[' && !this.searchLineEnd(token) &&
-        conf.around && typeof(conf.around.brackets) !== 'undefined') {
-      this.clearWhitespace(token, 'next');
-      this.clearWhitespace(token.twin, 'prev');
-      if(conf.around.brackets) {
-        this.appendWhitespace(token);
-        this.prependWhitespace(token.twin);
-      }
-    }
-    if(token.value === '(' && !this.searchLineEnd(token) &&
-        conf.around && typeof(conf.around.parentheses) !== 'undefined') {
-      this.clearWhitespace(token, 'next');
-      this.clearWhitespace(token.twin, 'prev');
-      if(conf.around.parentheses) {
-        this.appendWhitespace(token);
-        this.prependWhitespace(token.twin);
+      if(token.value === '(' && typeof(conf.around.parentheses) !== 'undefined') {
+        this.clearWhitespace(token, 'next');
+        this.clearWhitespace(token.twin, 'prev');
+        if(conf.around.parentheses) {
+          this.appendWhitespace(token);
+          this.prependWhitespace(token.twin);
+        }
       }
     }
   } while(token = token.next);

--- a/lib/plugins/spacing.js
+++ b/lib/plugins/spacing.js
@@ -1,6 +1,6 @@
 var SpacingPlugin = module.exports = {};
 SpacingPlugin.transform = function(tokens, type) {
-  var conf = typeof(type) === 'object' ? type : this.config[type];
+  var conf = typeof(type) === 'object' ? type : this.presets[type];
   var token = tokens.first;
   
   do {
@@ -64,7 +64,7 @@ SpacingPlugin.transform = function(tokens, type) {
     }
   } while(token = token.next);
 };
-SpacingPlugin.config = {
+SpacingPlugin.presets = {
   'node': {
     'before': {
       'methodDeclaration': false,

--- a/lib/plugins/spacing.js
+++ b/lib/plugins/spacing.js
@@ -2,6 +2,17 @@ var SpacingPlugin = module.exports = {};
 SpacingPlugin.transform = function(tokens, type) {
   var conf = typeof(type) === 'object' ? type : this.presets[type];
   var token = tokens.first;
+  var assignmentOps = [
+    '=', '*=', '/=', '%=', '+=', '-=', 
+    '<<=', '>>=', '>>>=', '&=', '^=', '!='
+  ];
+  var logicalOps = ['&&', '||'];
+  var relationalOps = ['<', '>', '<=', '>=', 'instanceof', 'in'];
+  var equalOps = ['==', '!=', '===', '!=='];
+  var bitwiseOps = ['&', '^', '|'];
+  var condOps = ['?', ':'];
+  var mathOps = ['+', '-', '/', '*', '%'];
+  var shiftOps = ['<<', '>>', '>>>'];
   
   do {
     if(token.value === '(' && token.methodDecl &&
@@ -38,7 +49,6 @@ SpacingPlugin.transform = function(tokens, type) {
         this.prependWhitespace(token);
       }
     }
-    // TODO: token.next.lineEnd is maybe not sufficient
     if(token.value === ',' && conf.after && !this.searchLineEnd(token) &&
         typeof(conf.after.comma) !== 'undefined') {
       this.clearWhitespace(token, 'next');
@@ -46,7 +56,6 @@ SpacingPlugin.transform = function(tokens, type) {
         this.appendWhitespace(token);
       }
     }
-    // TODO: token.next.lineEnd is maybe not sufficient
     if(token.value === ';' && conf.after && !this.searchLineEnd(token) &&
         typeof(conf.after.semicolon) !== 'undefined') {
       var foo = token;
@@ -59,6 +68,79 @@ SpacingPlugin.transform = function(tokens, type) {
         typeof(conf.after.logicalNot) !== 'undefined') {
       this.clearWhitespace(token, 'next');
       if(conf.after.logicalNot) {
+        this.appendWhitespace(token);
+      }
+    }
+    if(assignmentOps.indexOf(token.value) != -1 && conf.around 
+        && typeof(conf.around.assignmentOp) !== 'undefined') {
+      this.clearWhitespace(token, 'prev');
+      this.clearWhitespace(token, 'next');
+      if(conf.around.assignmentOp) {
+        this.prependWhitespace(token);
+        this.appendWhitespace(token);
+      }
+    }
+    if(logicalOps.indexOf(token.value) != -1 && conf.around 
+        && typeof(conf.around.logicalOp) !== 'undefined') {
+      this.clearWhitespace(token, 'prev');
+      this.clearWhitespace(token, 'next');
+      if(conf.around.logicalOp) {
+        this.prependWhitespace(token);
+        this.appendWhitespace(token);
+      }
+    }
+    if(relationalOps.indexOf(token.value) != -1 && conf.around 
+        && typeof(conf.around.relationalOp) !== 'undefined') {
+      this.clearWhitespace(token, 'prev');
+      this.clearWhitespace(token, 'next');
+      if(conf.around.relationalOp) {
+        this.prependWhitespace(token);
+        this.appendWhitespace(token);
+      }
+    }
+    if(equalOps.indexOf(token.value) != -1 && conf.around 
+        && typeof(conf.around.equalOp) !== 'undefined') {
+      this.clearWhitespace(token, 'prev');
+      this.clearWhitespace(token, 'next');
+      if(conf.around.equalOp) {
+        this.prependWhitespace(token);
+        this.appendWhitespace(token);
+      }
+    }
+    if(bitwiseOps.indexOf(token.value) != -1 && conf.around 
+        && typeof(conf.around.bitwiseOp) !== 'undefined') {
+      this.clearWhitespace(token, 'prev');
+      this.clearWhitespace(token, 'next');
+      if(conf.around.bitwiseOp) {
+        this.prependWhitespace(token);
+        this.appendWhitespace(token);
+      }
+    }
+    // TODO: differentiate from case colons
+    if(condOps.indexOf(token.value) != -1 && conf.around 
+        && typeof(conf.around.condOp) !== 'undefined') {
+      this.clearWhitespace(token, 'prev');
+      this.clearWhitespace(token, 'next');
+      if(conf.around.condOp) {
+        this.prependWhitespace(token);
+        this.appendWhitespace(token);
+      }
+    }
+    if(mathOps.indexOf(token.value) != -1 && conf.around 
+        && typeof(conf.around.mathOp) !== 'undefined') {
+      this.clearWhitespace(token, 'prev');
+      this.clearWhitespace(token, 'next');
+      if(conf.around.mathOp) {
+        this.prependWhitespace(token);
+        this.appendWhitespace(token);
+      }
+    }
+    if(shiftOps.indexOf(token.value) != -1 && conf.around 
+        && typeof(conf.around.shiftOp) !== 'undefined') {
+      this.clearWhitespace(token, 'prev');
+      this.clearWhitespace(token, 'next');
+      if(conf.around.shiftOp) {
+        this.prependWhitespace(token);
         this.appendWhitespace(token);
       }
     }
@@ -82,8 +164,9 @@ SpacingPlugin.presets = {
       'assignmentOp': true,
       'logicalOp': true,
       'relationalOp': true,
+      'equalOps': true,
       'bitwiseOp': true,
-      'conditionalOp': true,
+      'condOp': true,
       'mathOp': true,
       'shiftOp': true,
       'braces': false,
@@ -109,8 +192,9 @@ SpacingPlugin.presets = {
       'assignmentOp': true,
       'logicalOp': true,
       'relationalOp': true,
+      'equalOps': true,
       'bitwiseOp': true,
-      'conditionalOp': true,
+      'condOp': true,
       'mathOp': true,
       'shiftOp': true,
       'braces': false,
@@ -153,7 +237,7 @@ SpacingPlugin.isCaseColon = function(token) {
     }
   };
   return false;
-}
+};
 
 SpacingPlugin.searchLineEnd = function(token) {
   var origToken = token;
@@ -164,4 +248,4 @@ SpacingPlugin.searchLineEnd = function(token) {
   }
   if(token === null) return true;
   return false;
-}
+};

--- a/lib/token.js
+++ b/lib/token.js
@@ -19,6 +19,7 @@ function Token(properties, tokens) {
   this.callStart   = false; // Boolean: True if token is a call expression start
   this.stmtStart   = false; // Boolean: True if token is the start of a statement
   this.methodDecl  = false; // Boolean: True if punctuation token is part of a method declaration
+  this.unary       = false; // Boolean: True if the token (-, +, ...) is a unary operation
 
   this._tokens  = tokens; // The parent token set
   this._zeToken = null; // Only use for debugging (!)

--- a/lib/token.js
+++ b/lib/token.js
@@ -16,6 +16,9 @@ function Token(properties, tokens) {
   this.comment     = false; // Boolean: True if comment
   this.error       = false; // Boolean: True if error token
   this.objLiteral  = false; // Boolean: True if token is an object literal
+  this.callStart   = false; // Boolean: True if token is a call expression start
+  this.stmtStart   = false; // Boolean: True if token is the start of a statement
+  this.methodDecl  = false; // Boolean: True if punctuation token is part of a method declaration
 
   this._tokens  = tokens; // The parent token set
   this._zeToken = null; // Only use for debugging (!)

--- a/test/integration/test-spacing.js
+++ b/test/integration/test-spacing.js
@@ -451,3 +451,84 @@ helper.test({
   expected:
     'var a = foo >>> bar;'
 });
+
+helper.test({
+  description:
+    'Test braces no spacing (around)',
+  options:
+    {spacing: {around: {braces: false}}},
+  input:
+    'var a = { foo:bar };',
+  expected:
+    'var a = {foo:bar};'
+});
+
+helper.test({
+  description:
+    'Test braces spacing (around)',
+  options:
+    {spacing: {around: {braces: true}}},
+  input:
+    'var a = {foo:bar};',
+  expected:
+    'var a = { foo:bar };'
+});
+
+helper.test({
+  description:
+    'Test braces spacing (around). No manipulation',
+  options:
+    {spacing: {around: {braces: true}}},
+  input:
+    'var a = { \n' +
+    '  foo:bar\n' +
+    '};',
+  expected:
+    'var a = { \n' +
+    '  foo:bar\n' +
+    '};'
+});
+
+helper.test({
+  description:
+    'Test brackets no spacing (around)',
+  options:
+    {spacing: {around: {brackets: false}}},
+  input:
+    'var a = [ foo, bar, baz ];',
+  expected:
+    'var a = [foo, bar, baz];'
+});
+
+helper.test({
+  description:
+    'Test brackets spacing (around)',
+  options:
+    {spacing: {around: {brackets: true}}},
+  input:
+    'var a = [foo, bar, baz];',
+  expected:
+    'var a = [ foo, bar, baz ];'
+});
+
+helper.test({
+  description:
+    'Test parentheses no spacing (around)',
+  options:
+    {spacing: {around: {parentheses: false}}},
+  input:
+    'var a = ( foo || bar && baz );',
+  expected:
+    'var a = (foo || bar && baz);'
+});
+
+helper.test({
+  description:
+    'Test parentheses spacing (around)',
+  options:
+    {spacing: {around: {parentheses: true}}},
+  input:
+    'var a = foo(bar,baz);',
+  expected:
+    'var a = foo( bar,baz );'
+});

--- a/test/integration/test-spacing.js
+++ b/test/integration/test-spacing.js
@@ -477,6 +477,19 @@ helper.test({
 
 helper.test({
   description:
+    'Test math-op spacing (around). Do not touch new line',
+  options:
+    {spacing: {around: {mathOp: true}}},
+  input:
+    'var a = foo + bar +\n' +
+    '  baz;',
+  expected:
+    'var a = foo + bar +\n' +
+    '  baz;'
+});
+
+helper.test({
+  description:
     'Test shift-op no spacing (around)',
   options:
     {spacing: {around: {shiftOp: false}}},
@@ -576,4 +589,15 @@ helper.test({
     'var a = foo(bar,baz);',
   expected:
     'var a = foo( bar,baz );'
+});
+
+helper.test({
+  description:
+    'Unary operator test',
+  options:
+    {spacing: {around: {mathOp: true}}},
+  input:
+    'var a = -1+1;',
+  expected:
+    'var a = -1 + 1;'
 });

--- a/test/integration/test-spacing.js
+++ b/test/integration/test-spacing.js
@@ -639,7 +639,7 @@ helper.test({
     'var a = function(bar, baz) /*comment*/ {};'
 });
 
-helper.test(true, {
+helper.test({
   description:
     'Comment test with around (do not strip it)',
   options:
@@ -650,7 +650,7 @@ helper.test(true, {
     'var a = bar/*comment*/+/* comment */baz;'
 });
 
-helper.test(true, {
+helper.test({
   description:
     'Comment test with around and parentheses (do not strip it)',
   options:
@@ -661,7 +661,7 @@ helper.test(true, {
     'var a = (/*comment*/foo || bar && baz/*comment*/);'
 });
 
-helper.test(true, {
+helper.test({
   description:
     'Do not touch direct neighbors for parantheses spacing',
   options:

--- a/test/integration/test-spacing.js
+++ b/test/integration/test-spacing.js
@@ -251,7 +251,7 @@ helper.test({
   input:
     'if(!foo && !bar){}',
   expected:
-    'if(! foo && ! bar){}',
+    'if(! foo && ! bar){}'
 });
 
 helper.test({
@@ -262,7 +262,7 @@ helper.test({
   input:
     'if(!foo && !bar){}',
   expected:
-    'if(! foo && ! bar){}',
+    'if(! foo && ! bar){}'
 });
 
 helper.test({
@@ -273,5 +273,181 @@ helper.test({
   input:
     'if(!!foo){}',
   expected:
-    'if(!! foo){}',
+    'if(!! foo){}'
+});
+
+helper.test({
+  description:
+    'Test assignment-op no spacing (around)',
+  options:
+    {spacing: {around: {assignmentOp: false}}},
+  input:
+    'foo >>= bar;',
+  expected:
+    'foo>>=bar;'
+});
+
+helper.test({
+  description:
+    'Test assignment-op spacing (around)',
+  options:
+    {spacing: {around: {assignmentOp: true}}},
+  input:
+    'foo>>=bar;',
+  expected:
+    'foo >>= bar;'
+});
+
+helper.test({
+  description:
+    'Test logical-op no spacing (around)',
+  options:
+    {spacing: {around: {logicalOp: false}}},
+  input:
+    'var a = foo && bar;',
+  expected:
+    'var a = foo&&bar;'
+});
+
+helper.test({
+  description:
+    'Test logical-op spacing (around)',
+  options:
+    {spacing: {around: {logicalOp: true}}},
+  input:
+    'var a = foo||bar;',
+  expected:
+    'var a = foo || bar;'
+});
+
+helper.test({
+  description:
+    'Test relational-op no spacing (around)',
+  options:
+    {spacing: {around: {relationalOp: false}}},
+  input:
+    'var a = foo >= bar;',
+  expected:
+    'var a = foo>=bar;'
+});
+
+helper.test({
+  description:
+    'Test relational-op spacing (around)',
+  options:
+    {spacing: {around: {relationalOp: true}}},
+  input:
+    'var a = foo>bar;',
+  expected:
+    'var a = foo > bar;'
+});
+
+helper.test({
+  description:
+    'Test equal-op no spacing (around)',
+  options:
+    {spacing: {around: {equalOp: false}}},
+  input:
+    'var a = foo === bar;',
+  expected:
+    'var a = foo===bar;'
+});
+
+helper.test({
+  description:
+    'Test equal-op spacing (around)',
+  options:
+    {spacing: {around: {equalOp: true}}},
+  input:
+    'var a = foo!=bar;',
+  expected:
+    'var a = foo != bar;'
+});
+
+helper.test({
+  description:
+    'Test bitwise-op no spacing (around)',
+  options:
+    {spacing: {around: {bitwiseOp: false}}},
+  input:
+    'var a = foo & bar;',
+  expected:
+    'var a = foo&bar;'
+});
+
+helper.test({
+  description:
+    'Test bitwise-op spacing (around)',
+  options:
+    {spacing: {around: {bitwiseOp: true}}},
+  input:
+    'var a = foo^bar;',
+  expected:
+    'var a = foo ^ bar;'
+});
+
+helper.test({
+  description:
+    'Test cond-op no spacing (around)',
+  options:
+    {spacing: {around: {condOp: false}}},
+  input:
+    'var a = foo ? bar : baz;',
+  expected:
+    'var a = foo?bar:baz;'
+});
+
+helper.test({
+  description:
+    'Test bitwise-op spacing (around)',
+  options:
+    {spacing: {around: {condOp: true}}},
+  input:
+    'var a = foo?bar:baz;',
+  expected:
+    'var a = foo ? bar : baz;'
+});
+
+helper.test({
+  description:
+    'Test math-op no spacing (around)',
+  options:
+    {spacing: {around: {mathOp: false}}},
+  input:
+    'var a = foo + bar;',
+  expected:
+    'var a = foo+bar;'
+});
+
+helper.test({
+  description:
+    'Test math-op spacing (around)',
+  options:
+    {spacing: {around: {mathOp: true}}},
+  input:
+    'var a = foo%bar;',
+  expected:
+    'var a = foo % bar;'
+});
+
+helper.test({
+  description:
+    'Test shift-op no spacing (around)',
+  options:
+    {spacing: {around: {shiftOp: false}}},
+  input:
+    'var a = foo << bar;',
+  expected:
+    'var a = foo<<bar;'
+});
+
+helper.test({
+  description:
+    'Test shift-op spacing (around)',
+  options:
+    {spacing: {around: {shiftOp: true}}},
+  input:
+    'var a = foo>>>bar;',
+  expected:
+    'var a = foo >>> bar;'
 });

--- a/test/integration/test-spacing.js
+++ b/test/integration/test-spacing.js
@@ -126,6 +126,21 @@ helper.test({
 
 helper.test({
   description:
+    'Test braces spacing (before). No spacing because on own line.',
+  options:
+    {spacing: {before: {braces: true}}},
+  input:
+    '  function foo()\n' +
+    '  {\n' +
+    '  }',
+  expected:
+    '  function foo()\n' +
+    '  {\n' +
+    '  }'
+});
+
+helper.test({
+  description:
     'Test case colon spacing (before)',
   options:
     {spacing: {before: {caseColon: true}}},

--- a/test/integration/test-spacing.js
+++ b/test/integration/test-spacing.js
@@ -399,13 +399,58 @@ helper.test({
 
 helper.test({
   description:
-    'Test bitwise-op spacing (around)',
+    'Test cond-op spacing (around)',
   options:
     {spacing: {around: {condOp: true}}},
   input:
     'var a = foo?bar:baz;',
   expected:
     'var a = foo ? bar : baz;'
+});
+
+helper.test({
+  description:
+    'Test cond-op spacing (around). No changes in object literal.',
+  options:
+    {spacing: {around: {condOp: true}}},
+  input:
+    'var a = {\n' +
+    '  foo:bar,\n' +
+    '  bar:baz\n' +
+    '};',
+  expected:
+    'var a = {\n' +
+    '  foo:bar,\n' +
+    '  bar:baz\n' +
+    '};'
+});
+
+helper.test({
+  description:
+    'Test cond-op spacing (around). On new lines.',
+  options:
+    {spacing: {around: {condOp: true}}},
+  input:
+    'var a = foo ?\n' +
+    '  bar:baz;',
+  expected:
+    'var a = foo ?\n' +
+    '  bar : baz;'
+});
+
+helper.test({
+  description:
+    'Test cond-op spacing (around). ":" on own line.',
+  options:
+    {spacing: {around: {condOp: true}}},
+  input:
+    'var a = foo ?\n' +
+    '  bar:\n' +
+    '  baz;',
+  expected:
+    'var a = foo ?\n' +
+    '  bar:\n' +
+    '  baz;',
 });
 
 helper.test({

--- a/test/integration/test-spacing.js
+++ b/test/integration/test-spacing.js
@@ -660,3 +660,14 @@ helper.test(true, {
   expected:
     'var a = (/*comment*/foo || bar && baz/*comment*/);'
 });
+
+helper.test(true, {
+  description:
+    'Do not touch direct neighbors for parantheses spacing',
+  options:
+    {spacing: {around: {parantheses: true}}},
+  input:
+    'var a = foo();',
+  expected:
+    'var a = foo();'
+});

--- a/test/integration/test-spacing.js
+++ b/test/integration/test-spacing.js
@@ -616,3 +616,47 @@ helper.test({
   expected:
     'var a = -1 + 1;'
 });
+
+helper.test({
+  description:
+    'Comment test with after (do not strip it)',
+  options:
+    {spacing: {after: {comma: false}}},
+  input:
+    'var a = function(foo, /*comment*/ bar);',
+  expected:
+    'var a = function(foo,/*comment*/bar);'
+});
+
+helper.test({
+  description:
+    'Comment test with before (do not strip it)',
+  options:
+    {spacing: {before: {braces: true}}},
+  input:
+    'var a = function(bar, baz)   /*comment*/  {};',
+  expected:
+    'var a = function(bar, baz) /*comment*/ {};'
+});
+
+helper.test(true, {
+  description:
+    'Comment test with around (do not strip it)',
+  options:
+    {spacing: {around: {mathOp: false}}},
+  input:
+    'var a = bar /*comment*/ + /* comment */ baz;',
+  expected:
+    'var a = bar/*comment*/+/* comment */baz;'
+});
+
+helper.test(true, {
+  description:
+    'Comment test with around and parentheses (do not strip it)',
+  options:
+    {spacing: {around: {parentheses: false}}},
+  input:
+    'var a = (/*comment*/ foo || bar && baz /*comment*/);',
+  expected:
+    'var a = (/*comment*/foo || bar && baz/*comment*/);'
+});

--- a/test/integration/test-spacing.js
+++ b/test/integration/test-spacing.js
@@ -1,0 +1,277 @@
+var TransformHelper = require('../common').helper('transform_helper');
+var helper = TransformHelper.create();
+
+helper.test({
+  description:
+    'Test string configuration',
+  options:
+    {spacing: 'node'},
+  input:
+    'function foo (bar, baz){};',
+  expected:
+    'function foo(bar, baz) {};'
+});
+
+helper.test({
+  description:
+    'Test method declaration no spacing (before)',
+  options:
+    {spacing: {before: {methodDeclaration: false}}},
+  input:
+    'function foo (bar, baz){};',
+  expected:
+    'function foo(bar, baz){};'
+});
+
+helper.test({
+  description:
+    'Test method declaration spacing (before)',
+  options:
+    {spacing: {before: {methodDeclaration: true}}},
+  input:
+    'function foo(bar, baz){};',
+  expected:
+    'function foo (bar, baz){};'
+});
+
+helper.test({
+  description:
+    'Test method call spacing (before)',
+  options:
+    {spacing: {before: {methodCall: true}}},
+  input:
+    'var foo = bar();',
+  expected:
+    'var foo = bar ();'
+});
+
+helper.test({
+  description:
+    'Test method call no spacing (before)',
+  options:
+    {spacing: {before: {methodCall: false}}},
+  input:
+    'var foo = bar ();',
+  expected:
+    'var foo = bar();'
+});
+
+helper.test({
+  description:
+    'Test statement spacing (before)',
+  options:
+    {spacing: {before: {statement: true}}},
+  input:
+    'while(a){};',
+  expected:
+    'while (a){};'
+});
+
+helper.test({
+  description:
+    'Test statement no spacing (before)',
+  options:
+    {spacing: {before: {statement: false}}},
+  input:
+    'if (a){};',
+  expected:
+    'if(a){};'
+});
+
+helper.test({
+  description:
+    'Test braces no spacing (before)',
+  options:
+    {spacing: {before: {braces: false}}},
+  input:
+    'if(a) {};',
+  expected:
+    'if(a){};'
+});
+
+helper.test({
+  description:
+    'Test braces spacing (before)',
+  options:
+    {spacing: {before: {braces: true}}},
+  input:
+    'function foo(){};',
+  expected:
+    'function foo() {};'
+});
+
+helper.test({
+  description:
+    'Test braces spacing with do (before)',
+  options:
+    {spacing: {before: {braces: true}}},
+  input:
+    'do{\n'+
+    '}while(foo);',
+  expected:
+    'do {\n'+
+    '}while(foo);'
+});
+
+helper.test({
+  description:
+    'Test braces no spacing (before) on object literal',
+  options:
+    {spacing: {before: {braces: false}}},
+  input:
+    'function foo() {};var bar =   {};',
+  expected:
+    'function foo(){};var bar =   {};',
+});
+
+helper.test({
+  description:
+    'Test case colon spacing (before)',
+  options:
+    {spacing: {before: {caseColon: true}}},
+  input:
+    'switch(foo) {\n' +
+    '  case "bar": break;\n' + 
+    '}',
+  expected:
+    'switch(foo) {\n' +
+    '  case "bar" : break;\n' + 
+    '}',
+});
+
+helper.test({
+  description:
+    'Test conditional colon (before) - no change',
+  options:
+    {spacing: {before: {caseColon: false}}},
+  input:
+    'var foo = bar ? true : false;',
+  expected:
+    'var foo = bar ? true : false;',
+});
+
+helper.test({
+  description:
+    'Test comma no spacing (after)',
+  options:
+    {spacing: {after: {comma: false}}},
+  input:
+    'var foo = bar(a, b, c, d);',
+  expected:
+    'var foo = bar(a,b,c,d);',
+});
+
+helper.test({
+  description:
+    'Test comma spacing (after)',
+  options:
+    {spacing: {after: {comma: true}}},
+  input:
+    'var foo = bar(a,b,c,d);',
+  expected:
+    'var foo = bar(a, b, c, d);',
+});
+
+helper.test({
+  description:
+    'Test comma spacing (after). Not on new line',
+  options:
+    {spacing: {after: {comma: true}}},
+  input:
+    'var foo = bar(\n' +
+    '  a,\n' +
+    '  b,\n' +
+    '  c\n' +
+    ');',
+  expected:
+    'var foo = bar(\n' +
+    '  a,\n' +
+    '  b,\n' +
+    '  c\n' +
+    ');'
+});
+
+helper.test({
+  description:
+    'Test semicolon no spacing (after)',
+  options:
+    {spacing: {after: {semicolon: false}}},
+  input:
+    'for(var i=0; i<a.length; i++){}',
+  expected:
+    'for(var i=0;i<a.length;i++){}'
+});
+
+helper.test({
+  description:
+    'Test semicolon spacing (after)',
+  options:
+    {spacing: {after: {semicolon: true}}},
+  input:
+    'for(var i=0;i<a.length;i++){}',
+  expected:
+    'for(var i=0; i<a.length; i++){}'
+});
+
+helper.test({
+  description:
+    'Test semicolon spacing (after). No changes on new line.',
+  options:
+    {spacing: {after: {semicolon: true}}},
+  input:
+    'for(\n' +
+    '  var i=0;\n' + 
+    '  i<a.length;\n' +
+    '  i++\n' +
+    '){};',
+  expected:
+    'for(\n' +
+    '  var i=0;\n' + 
+    '  i<a.length;\n' +
+    '  i++\n' +
+    '){};'
+});
+
+helper.test({
+  description:
+    'Test logical not no spacing (after)',
+  options:
+    {spacing: {after: {logicalNot: false}}},
+  input:
+    'if(! foo && ! bar){}',
+  expected:
+    'if(!foo && !bar){}'
+});
+
+helper.test({
+  description:
+    'Test logical not spacing (after)',
+  options:
+    {spacing: {after: {logicalNot: true}}},
+  input:
+    'if(!foo && !bar){}',
+  expected:
+    'if(! foo && ! bar){}',
+});
+
+helper.test({
+  description:
+    'Test logical not spacing (after)',
+  options:
+    {spacing: {after: {logicalNot: true}}},
+  input:
+    'if(!foo && !bar){}',
+  expected:
+    'if(! foo && ! bar){}',
+});
+
+helper.test({
+  description:
+    'Test double logical not spacing (after)',
+  options:
+    {spacing: {after: {logicalNot: true}}},
+  input:
+    'if(!!foo){}',
+  expected:
+    'if(!! foo){}',
+});


### PR DESCRIPTION
This feature adds the possibility to manage the spacing between various tokens. You can configure it by either passing one of the presets: `node`, `dojo`, `jquery`. For fine-grained control you could also define your own object in syntax.json: https://github.com/evilhackerdude/syntux/blob/spacing/lib/plugins/spacing.js#L102:L126. From CLI you just will be able to define one of the presets.
